### PR TITLE
Feature/tao 7148 update jquery

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -28,11 +28,12 @@ return array(
 	'label' => 'extension-tao-dac-simple',
 	'description' => 'extension that allows admin to give access to some resources to other people',
     'license' => 'GPL-2.0',
-    'version' => '3.0.0',
+    'version' => '3.1.0',
 	'author' => 'Open Assessment Technologies SA',
 	'requires' => array(
 	   'taoBackOffice' => '>=3.0.0',
-        'generis' => '>=5.9.0'
+       'generis' => '>=5.9.0',
+       'tao' => '>=23.0.0'
     ),
 	// for compatibility
 	'dependencies' => array('tao', 'taoItems'),

--- a/manifest.php
+++ b/manifest.php
@@ -28,7 +28,7 @@ return array(
 	'label' => 'extension-tao-dac-simple',
 	'description' => 'extension that allows admin to give access to some resources to other people',
     'license' => 'GPL-2.0',
-    'version' => '3.1.0',
+    'version' => '3.2.0',
 	'author' => 'Open Assessment Technologies SA',
 	'requires' => array(
 	   'taoBackOffice' => '>=3.0.0',

--- a/manifest.php
+++ b/manifest.php
@@ -33,7 +33,7 @@ return array(
 	'requires' => array(
 	   'taoBackOffice' => '>=3.0.0',
        'generis' => '>=5.9.0',
-       'tao' => '>=23.0.0'
+       'tao' => '>=24.0.0'
     ),
 	// for compatibility
 	'dependencies' => array('tao', 'taoItems'),

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -137,6 +137,6 @@ class Updater extends \common_ext_ExtensionUpdater {
             $this->setVersion('2.7.0');
         }
 
-        $this->skip('2.7.0', '3.1.0');
+        $this->skip('2.7.0', '3.2.0');
     }
 }

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -137,6 +137,6 @@ class Updater extends \common_ext_ExtensionUpdater {
             $this->setVersion('2.7.0');
         }
 
-        $this->skip('2.7.0', '3.0.0');
+        $this->skip('2.7.0', '3.1.0');
     }
 }

--- a/views/js/controller/admin/index.js
+++ b/views/js/controller/admin/index.js
@@ -107,8 +107,8 @@ define([
         $canChangeWrite.removeClass('disabled');
         $canChangeRead.removeClass('disabled');
 
-        $cantChangeWrite.addClass('disabled').attr('checked', true);
-        $cantChangeRead.addClass('disabled').attr('checked', true);
+        $cantChangeWrite.addClass('disabled').prop('checked', true);
+        $cantChangeRead.addClass('disabled').prop('checked', true);
 
         _preventManagerRemoval($container);
         _disableAccessOnWrite($container);
@@ -130,7 +130,7 @@ define([
 
         $canChangeRead.removeClass('disabled');
 
-        $cantChangeRead.addClass('disabled').attr('checked', true);
+        $cantChangeRead.addClass('disabled').prop('checked', true);
     };
 
     /**


### PR DESCRIPTION
Update the extension to support jQuery 1.9.1

 Requires : 
 - [ ] https://github.com/oat-sa/tao-core/pull/1920 

Changes : 
 - `.prop` needs to be used for checkboxes instead of `.attr`