### PR TITLE
TTD-18 Tests extends from `generis\test\TestCase`. All mock objects e…

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -32,7 +32,7 @@ return array(
 	'author' => 'Open Assessment Technologies SA',
 	'requires' => array(
 	   'taoBackOffice' => '>=3.0.0',
-       'generis' => '>=12.3.0',
+       'generis' => '>=12.5.0',
        'tao' => '>=34.0.0'
     ),
 	// for compatibility

--- a/manifest.php
+++ b/manifest.php
@@ -28,7 +28,7 @@ return array(
 	'label' => 'extension-tao-dac-simple',
 	'description' => 'extension that allows admin to give access to some resources to other people',
     'license' => 'GPL-2.0',
-    'version' => '5.0.1',
+    'version' => '5.1.0',
 	'author' => 'Open Assessment Technologies SA',
 	'requires' => array(
 	   'taoBackOffice' => '>=3.0.0',

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -137,6 +137,6 @@ class Updater extends \common_ext_ExtensionUpdater {
             $this->setVersion('2.7.0');
         }
 
-        $this->skip('2.7.0', '5.0.1');
+        $this->skip('2.7.0', '5.1.0');
     }
 }

--- a/test/unit/model/DataBaseAccessTest.php
+++ b/test/unit/model/DataBaseAccessTest.php
@@ -23,6 +23,7 @@ namespace oat\taoDacSimple\test\unit\model;
 
 use oat\generis\test\TestCase;
 use oat\taoDacSimple\model\DataBaseAccess;
+use oat\generis\test\MockObject;
 
 /**
  * Test database access
@@ -47,7 +48,7 @@ class DataBaseAccessTest extends TestCase {
 
     /**
      * Return a persistence Mock object
-     * @return \PHPUnit_Framework_MockObject_MockObject
+     * @return MockObject
      */
     public function getPersistenceMock($queryParams, $queryFixture, $resultFixture) {
 


### PR DESCRIPTION
Related to: https://oat-sa.atlassian.net/browse/TTD-18
Depends on: https://github.com/oat-sa/generis/pull/678
All tests extends `generis\test\TestCase` instead of `\PHPUnit_Framework_TestCase`
All Mock objects instances of `generis\test\MockObject` instead of `\PHPUnit_Framework_MockObject_MockObject`. Mocks was used only in phpdoc.
Possible way to test:
1) run unit tests.
2) update code.
3) run unit tests again. result should be the same as in 1.