### PR TITLE
Fix/uno 586/when searching for atl for items error

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -30,7 +30,7 @@ return [
     'label' => 'extension-tao-dac-simple',
     'description' => 'extension that allows admin to give access to some resources to other people',
     'license' => 'GPL-2.0',
-    'version' => '6.8.2',
+    'version' => '6.8.3',
     'author' => 'Open Assessment Technologies SA',
     'requires' => [
        'taoBackOffice' => '>=3.0.0',

--- a/model/DataBaseAccess.php
+++ b/model/DataBaseAccess.php
@@ -90,6 +90,10 @@ class DataBaseAccess extends ConfigurableService
      */
     public function getPermissions($userIds, array $resourceIds)
     {
+        // permission request for empty resources must return an empty array
+        if (!count($resourceIds)) {
+            return [];
+        }
         // get privileges for a user/roles and a resource
         $inQueryResource = implode(',', array_fill(0, count($resourceIds), '?'));
         $inQueryUser = implode(',', array_fill(0, count($userIds), '?'));

--- a/test/unit/model/DataBaseAccessTest.php
+++ b/test/unit/model/DataBaseAccessTest.php
@@ -181,6 +181,7 @@ class DataBaseAccessTest extends TestCase
         $this->setPersistence($this->instance, $persistenceMock);
 
         $this->assertEquals($resultFixture, $this->instance->getPermissions($userIds, $resourceIds));
+        $this->assertEquals([], $this->instance->getPermissions($userIds, []));
     }
 
     private function setPersistence($instance, $persistenceMock)


### PR DESCRIPTION
__task:__ https://oat-sa.atlassian.net/browse/UNO-586
__description:__ When searching for "atl" for items error
__cause__: bad sql query if empty 'resourceIds' array 
![image](https://user-images.githubusercontent.com/18699340/92107495-9077ef80-edee-11ea-92ab-4ef7b064a34b.png)
IN operator parameters cannot be empty

__test step__: 
1. Log in as Author
2. in the search box on the Items tab enter a non-existing item label 
![image](https://user-images.githubusercontent.com/18699340/92107912-34619b00-edef-11ea-8f93-8b73a5171a68.png)
3.do a search

__expected result:__ The search shouldn't break. Search result must be empty
![image](https://user-images.githubusercontent.com/18699340/92108062-7094fb80-edef-11ea-81c9-a0925973f7fd.png)
