### PR TITLE
[Fix] ADF-260 - [FE] Non-meaningful error when try to save without any grant permission

### DIFF
--- a/views/js/controller/admin/index.js
+++ b/views/js/controller/admin/index.js
@@ -83,6 +83,7 @@ define([
 
         if (!_checkManagers($form)) {
             $submitter.addClass('disabled');
+            $submitter.attr('disabled', 'disabled');
             errorTooltip = tooltip.warning($submitter, errorMsgManagePermission, {
                 placement : 'bottom',
                 trigger: "hover",
@@ -90,6 +91,7 @@ define([
             feedback().warning(errorMsgManagePermission);
         } else {
             $submitter.removeClass('disabled');
+            $submitter.removeAttr('disabled');
             if(errorTooltip){
                 errorTooltip.dispose();
             }


### PR DESCRIPTION
**Ticket**
https://oat-sa.atlassian.net/browse/ADF-260

**Description**
When we try to save in access control without any grant permission (ignoring the popup warning for dont do that) we receive a non-meaningful error popup without text

**Steps to reproduce**

- Go to Items

- Select one item

- Click on Access control button (`dac-simple` extension should be enabled)

- Remove all grant permissions unchecking all checkboxes of the grant column

- Save

**Solution**
I've decided to avoid the problem by directly restricting the user's submit action from the view. The submitter button will now have the `disabled` attribute which will not allow any click events when there are no grant permission selected.