### PR TITLE
ADF-654: Fix persisting ACLs when applying a huge number of permissions at once

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,6 +21,7 @@
     },
     "minimum-stability" : "dev",
     "require": {
+        "php": ">=7.1",
         "oat-sa/oatbox-extension-installer": "~1.1||dev-master",
         "oat-sa/generis" : ">=14.0.0",
         "oat-sa/tao-core" : ">=48.0.0",

--- a/model/DataBaseAccess.php
+++ b/model/DataBaseAccess.php
@@ -23,6 +23,7 @@
 namespace oat\taoDacSimple\model;
 
 use common_persistence_SqlPersistence;
+use Doctrine\DBAL\Driver\Connection;
 use oat\oatbox\event\EventManager;
 use oat\oatbox\service\ConfigurableService;
 use oat\taoDacSimple\model\event\DacAddedEvent;
@@ -408,6 +409,10 @@ class DataBaseAccess extends ConfigurableService
                 'chunks' => ceil($insertCount / self::INSERT_CHUNK_SIZE)
             ]
         );
+
+        if(empty($insert)) {
+            return;
+        }
 
         $persistence->transactional(function () use ($insert, $logger, $insertCount, $persistence) {
             foreach (array_chunk($insert, self::INSERT_CHUNK_SIZE) as $index => $batch) {

--- a/model/DataBaseAccess.php
+++ b/model/DataBaseAccess.php
@@ -48,10 +48,14 @@ class DataBaseAccess extends ConfigurableService
     const TABLE_PRIVILEGES_NAME = 'data_privileges';
     const INDEX_RESOURCE_ID = 'data_privileges_resource_id_index';
 
-    private const INSERT_CHUNK_SIZE = 20000;
+    private $insertChunkSize = 20000;
 
     private $persistence;
 
+    public function setInsertChunkSize(int $size): void
+    {
+        $this->insertChunkSize = $size;
+    }
 
     /**
      * @return EventManager
@@ -403,7 +407,7 @@ class DataBaseAccess extends ConfigurableService
             'Processing {count} permission inserts in {chunks} chunks',
             [
                 'count' => count($insert),
-                'chunks' => ceil($insertCount / self::INSERT_CHUNK_SIZE)
+                'chunks' => ceil($insertCount / $this->insertChunkSize)
             ]
         );
 
@@ -412,12 +416,12 @@ class DataBaseAccess extends ConfigurableService
         }
 
         $persistence->transactional(function () use ($insert, $logger, $insertCount, $persistence) {
-            foreach (array_chunk($insert, self::INSERT_CHUNK_SIZE) as $index => $batch) {
+            foreach (array_chunk($insert, $this->insertChunkSize) as $index => $batch) {
                 $logger->debug(
                     'Processing chunk {index}/{total} with {items} ACL entries',
                     [
                         'index' => $index + 1,
-                        'total' => ceil($insertCount / self::INSERT_CHUNK_SIZE),
+                        'total' => ceil($insertCount / $this->insertChunkSize),
                         'items' => count($batch)
                     ]
                 );

--- a/model/DataBaseAccess.php
+++ b/model/DataBaseAccess.php
@@ -16,14 +16,11 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  *
  * Copyright (c) 2014 (original work) Open Assessment Technologies SA (under the project TAO-PRODUCT);
- *
- *
  */
 
 namespace oat\taoDacSimple\model;
 
 use common_persistence_SqlPersistence;
-use Doctrine\DBAL\Driver\Connection;
 use oat\oatbox\event\EventManager;
 use oat\oatbox\service\ConfigurableService;
 use oat\taoDacSimple\model\event\DacAddedEvent;
@@ -410,7 +407,7 @@ class DataBaseAccess extends ConfigurableService
             ]
         );
 
-        if(empty($insert)) {
+        if (empty($insert)) {
             return;
         }
 

--- a/model/DataBaseAccess.php
+++ b/model/DataBaseAccess.php
@@ -181,7 +181,7 @@ class DataBaseAccess extends ConfigurableService
         }
 
         $this->getLogger()->debug(
-            "Processing {count} permission inserts in {chunks} chunks",
+            'Processing {count} permission inserts in {chunks} chunks',
             [
                 'count' => count($insert),
                 'chunks' => ceil(count($insert)/self::INSERT_CHUNK_SIZE)
@@ -190,7 +190,7 @@ class DataBaseAccess extends ConfigurableService
 
         foreach(array_chunk($insert, self::INSERT_CHUNK_SIZE) as $index => $batch) {
             $this->getLogger()->debug(
-                "Processing chunk {index}/{total} with {items} ACL entries",
+                'Processing chunk {index}/{total} with {items} ACL entries',
                 [
                     'index' => $index + 1,
                     'total' => ceil(count($insert)/self::INSERT_CHUNK_SIZE),

--- a/model/DataBaseAccess.php
+++ b/model/DataBaseAccess.php
@@ -15,7 +15,7 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  *
- * Copyright (c) 2014 (original work) Open Assessment Technologies SA (under the project TAO-PRODUCT);
+ * Copyright (c) 2014-2021 (original work) Open Assessment Technologies SA (under the project TAO-PRODUCT);
  */
 
 namespace oat\taoDacSimple\model;
@@ -37,7 +37,6 @@ use Throwable;
  */
 class DataBaseAccess extends ConfigurableService
 {
-
     const SERVICE_ID = 'taoDacSimple/DataBaseAccess';
 
     const OPTION_PERSISTENCE = 'persistence';

--- a/model/DataBaseAccess.php
+++ b/model/DataBaseAccess.php
@@ -398,21 +398,13 @@ class DataBaseAccess extends ConfigurableService
      */
     private function insertPermissions(array $insert): void
     {
-        $logger = $this->getLogger();
-        $insertCount = count($insert);
-        $persistence = $this->getPersistence();
-
-        $logger->debug(
-            'Processing {count} permission inserts in {chunks} chunks',
-            [
-                'count' => count($insert),
-                'chunks' => ceil($insertCount / $this->insertChunkSize)
-            ]
-        );
-
         if (empty($insert)) {
             return;
         }
+        
+        $logger = $this->getLogger();
+        $insertCount = count($insert);
+        $persistence = $this->getPersistence();
 
         $persistence->transactional(function () use ($insert, $logger, $insertCount, $persistence) {
             foreach (array_chunk($insert, $this->insertChunkSize) as $index => $batch) {

--- a/model/DataBaseAccess.php
+++ b/model/DataBaseAccess.php
@@ -165,6 +165,7 @@ class DataBaseAccess extends ConfigurableService
      */
     public function addMultiplePermissions(array $permissionData)
     {
+        $logger = $this->getLogger();
         $insert = [];
         foreach ($permissionData as $permissionItem) {
             foreach ($permissionItem['permissions'] as $userId => $privilegeIds) {
@@ -181,7 +182,7 @@ class DataBaseAccess extends ConfigurableService
         }
 
         $insertCount = count($insert);
-        $this->getLogger()->debug(
+        $logger->debug(
             'Processing {count} permission inserts in {chunks} chunks',
             [
                 'count' => count($insert),
@@ -190,7 +191,7 @@ class DataBaseAccess extends ConfigurableService
         );
 
         foreach (array_chunk($insert, self::INSERT_CHUNK_SIZE) as $index => $batch) {
-            $this->getLogger()->debug(
+            $logger->debug(
                 'Processing chunk {index}/{total} with {items} ACL entries',
                 [
                     'index' => $index + 1,

--- a/model/DataBaseAccess.php
+++ b/model/DataBaseAccess.php
@@ -65,9 +65,10 @@ class DataBaseAccess extends ConfigurableService
     }
 
     /**
-     * We can know which users have a privilege on a resource
-     * @param array $resourceIds
-     * @return array list of users
+     * Retrieve info on users having privileges on a set of resources
+     *
+     * @param array $resourceIds IDs of resources to fetch privileges for
+     * @return array A list of rows containing resource ID, user ID and privilege name
      */
     public function getUsersWithPermissions($resourceIds)
     {
@@ -81,6 +82,7 @@ class DataBaseAccess extends ConfigurableService
             self::COLUMN_RESOURCE_ID,
             $inQuery
         );
+
         return $this->fetchQuery($query, $resourceIds);
     }
 
@@ -92,13 +94,13 @@ class DataBaseAccess extends ConfigurableService
      * @param array $resourceIds
      * @return array
      */
-    public function getPermissions($userIds, array $resourceIds)
+    public function getPermissions(array $userIds, array $resourceIds): array
     {
-        // permission request for empty resources must return an empty array
+        // Permissions for an empty set of resources must be an empty array
         if (!count($resourceIds)) {
             return [];
         }
-        // get privileges for a user/roles and a resource
+
         $inQueryResource = implode(',', array_fill(0, count($resourceIds), '?'));
         $inQueryUser = implode(',', array_fill(0, count($userIds), '?'));
         $query = sprintf(
@@ -126,17 +128,19 @@ class DataBaseAccess extends ConfigurableService
 
     public function getResourcesPermissions(array $resourceIds)
     {
-        //If resource doesn't have permission don't return null
-        $returnValue = array_fill_keys($resourceIds, []);
-        $results = $this->getUsersWithPermissions($resourceIds);
-        foreach ($results as $result) {
-            $returnValue[$result[self::COLUMN_RESOURCE_ID]][$result[self::COLUMN_USER_ID]][] = $result[self::COLUMN_PRIVILEGE];
+        // Return an empty array for resources not having permissions data
+        $grants = array_fill_keys($resourceIds, []);
+
+        foreach ($this->getUsersWithPermissions($resourceIds) as $entry) {
+            $grants[$entry[self::COLUMN_RESOURCE_ID]][$entry[self::COLUMN_USER_ID]][]
+                = $entry[self::COLUMN_PRIVILEGE];
         }
-        return $returnValue;
+
+        return $grants;
     }
 
     /**
-     * add permissions of a user to a resource
+     * Add permissions of a user to a resource
      *
      * @access public
      * @param string $user
@@ -147,14 +151,24 @@ class DataBaseAccess extends ConfigurableService
      */
     public function addPermissions($user, $resourceId, $rights)
     {
+        // Add an ACL item for each user URI, resource ID and privilege combination
         foreach ($rights as $privilege) {
-            // add a line with user URI, resource Id and privilege
             $this->getPersistence()->insert(
                 self::TABLE_PRIVILEGES_NAME,
-                [self::COLUMN_USER_ID => $user, self::COLUMN_RESOURCE_ID => $resourceId, self::COLUMN_PRIVILEGE => $privilege]
+                [
+                    self::COLUMN_USER_ID => $user,
+                    self::COLUMN_RESOURCE_ID => $resourceId,
+                    self::COLUMN_PRIVILEGE => $privilege
+                ]
             );
         }
-        $this->getEventManager()->trigger(new DacAddedEvent($user, $resourceId, (array)$rights));
+
+        $this->getEventManager()->trigger(new DacAddedEvent(
+            $user,
+            $resourceId,
+            (array)$rights
+        ));
+
         return true;
     }
 
@@ -203,7 +217,7 @@ class DataBaseAccess extends ConfigurableService
      */
     public function getResourcePermissions($resourceId)
     {
-        // get privileges for a user/roles and a resource
+        $grants = [];
         $query = sprintf(
             'SELECT %s, %s FROM %s WHERE %s = ?',
             self::COLUMN_USER_ID,
@@ -212,11 +226,11 @@ class DataBaseAccess extends ConfigurableService
             self::COLUMN_RESOURCE_ID
         );
 
-        $results = $this->fetchQuery($query, [$resourceId]);
-        foreach ($results as $result) {
-            $returnValue[$result[self::COLUMN_USER_ID]][] = $result[self::COLUMN_PRIVILEGE];
+        foreach ($this->fetchQuery($query, [$resourceId]) as $entry) {
+            $grants[$entry[self::COLUMN_USER_ID]][] = $entry[self::COLUMN_PRIVILEGE];
         }
-        return $returnValue ?? [];
+
+        return $grants;
     }
 
     /**
@@ -240,15 +254,21 @@ class DataBaseAccess extends ConfigurableService
             $inQueryPrivilege,
             self::COLUMN_USER_ID
         );
+
         $params = array_merge([$resourceId], array_values($rights), [$user]);
         $this->getPersistence()->exec($query, $params);
-        $this->getEventManager()->trigger(new DacRemovedEvent($user, $resourceId, $rights));
+
+        $this->getEventManager()->trigger(new DacRemovedEvent(
+            $user,
+            $resourceId,
+            $rights
+        ));
 
         return true;
     }
 
     /**
-     * remove batch permissions
+     * Remove batch permissions
      *
      * @access public
      * @param array $data
@@ -261,9 +281,17 @@ class DataBaseAccess extends ConfigurableService
         foreach ($data as $permissionItem) {
             foreach ($permissionItem['permissions'] as $userId => $privilegeIds) {
                 if (!empty($privilegeIds)) {
-                    $groupedRemove[$userId][implode($privilegeIds)]['resources'][] = $permissionItem['resource']->getUri();
-                    $groupedRemove[$userId][implode($privilegeIds)]['privileges'] = $privilegeIds;
-                    $eventsData[] = ['userId' => $userId, 'resourceId' => $permissionItem['resource']->getUri(), 'privileges' => $privilegeIds];
+                    $idString = implode($privilegeIds);
+                    $resource = &$permissionItem['resource'];
+
+                    $groupedRemove[$userId][$idString]['resources'][] = $resource->getUri();
+                    $groupedRemove[$userId][$idString]['privileges'] = $privilegeIds;
+
+                    $eventsData[] = [
+                        'userId' => $userId,
+                        'resourceId' => $resource->getUri(),
+                        'privileges' => $privilegeIds
+                    ];
                 }
             }
         }
@@ -280,12 +308,23 @@ class DataBaseAccess extends ConfigurableService
                     $inQueryPrivilege,
                     self::COLUMN_USER_ID
                 );
-                $params = array_merge(array_values($permissions['resources']), array_values($permissions['privileges']), [$userId]);
+
+                $params = array_merge(
+                    array_values($permissions['resources']),
+                    array_values($permissions['privileges']),
+                    [$userId]
+                );
+
                 $this->getPersistence()->exec($query, $params);
             }
         }
+
         foreach ($eventsData as $eventData) {
-            $this->getEventManager()->trigger(new DacRemovedEvent($eventData['userId'], $eventData['resourceId'], $eventData['privileges']));
+            $this->getEventManager()->trigger(new DacRemovedEvent(
+                $eventData['userId'],
+                $eventData['resourceId'],
+                $eventData['privileges']
+            ));
         }
     }
 
@@ -401,7 +440,7 @@ class DataBaseAccess extends ConfigurableService
         if (empty($insert)) {
             return;
         }
-        
+
         $logger = $this->getLogger();
         $insertCount = count($insert);
         $persistence = $this->getPersistence();

--- a/model/DataBaseAccess.php
+++ b/model/DataBaseAccess.php
@@ -48,7 +48,8 @@ class DataBaseAccess extends ConfigurableService
     const COLUMN_PRIVILEGE = 'privilege';
     const TABLE_PRIVILEGES_NAME = 'data_privileges';
     const INDEX_RESOURCE_ID = 'data_privileges_resource_id_index';
-    const INSERT_CHUNK_SIZE = 20000;
+
+    private const INSERT_CHUNK_SIZE = 20000;
 
     private $persistence;
 

--- a/model/DataBaseAccess.php
+++ b/model/DataBaseAccess.php
@@ -37,15 +37,15 @@ use Throwable;
  */
 class DataBaseAccess extends ConfigurableService
 {
-    const SERVICE_ID = 'taoDacSimple/DataBaseAccess';
+    public const SERVICE_ID = 'taoDacSimple/DataBaseAccess';
 
-    const OPTION_PERSISTENCE = 'persistence';
+    public const OPTION_PERSISTENCE = 'persistence';
 
-    const COLUMN_USER_ID = 'user_id';
-    const COLUMN_RESOURCE_ID = 'resource_id';
-    const COLUMN_PRIVILEGE = 'privilege';
-    const TABLE_PRIVILEGES_NAME = 'data_privileges';
-    const INDEX_RESOURCE_ID = 'data_privileges_resource_id_index';
+    public const COLUMN_USER_ID = 'user_id';
+    public const COLUMN_RESOURCE_ID = 'resource_id';
+    public const COLUMN_PRIVILEGE = 'privilege';
+    public const TABLE_PRIVILEGES_NAME = 'data_privileges';
+    public const INDEX_RESOURCE_ID = 'data_privileges_resource_id_index';
 
     private $insertChunkSize = 20000;
 

--- a/model/DataBaseAccess.php
+++ b/model/DataBaseAccess.php
@@ -279,10 +279,10 @@ class DataBaseAccess extends ConfigurableService
         $groupedRemove = [];
         $eventsData = [];
         foreach ($data as $permissionItem) {
+            $resource = &$permissionItem['resource'];
             foreach ($permissionItem['permissions'] as $userId => $privilegeIds) {
                 if (!empty($privilegeIds)) {
                     $idString = implode($privilegeIds);
-                    $resource = &$permissionItem['resource'];
 
                     $groupedRemove[$userId][$idString]['resources'][] = $resource->getUri();
                     $groupedRemove[$userId][$idString]['privileges'] = $privilegeIds;

--- a/model/DataBaseAccess.php
+++ b/model/DataBaseAccess.php
@@ -180,20 +180,21 @@ class DataBaseAccess extends ConfigurableService
             }
         }
 
+        $insertCount = count($insert);
         $this->getLogger()->debug(
             'Processing {count} permission inserts in {chunks} chunks',
             [
                 'count' => count($insert),
-                'chunks' => ceil(count($insert)/self::INSERT_CHUNK_SIZE)
+                'chunks' => ceil($insertCount / self::INSERT_CHUNK_SIZE)
             ]
         );
 
-        foreach(array_chunk($insert, self::INSERT_CHUNK_SIZE) as $index => $batch) {
+        foreach (array_chunk($insert, self::INSERT_CHUNK_SIZE) as $index => $batch) {
             $this->getLogger()->debug(
                 'Processing chunk {index}/{total} with {items} ACL entries',
                 [
                     'index' => $index + 1,
-                    'total' => ceil(count($insert)/self::INSERT_CHUNK_SIZE),
+                    'total' => ceil($insertCount / self::INSERT_CHUNK_SIZE),
                     'items' => count($batch)
                 ]
             );

--- a/test/unit/model/DataBaseAccessTest.php
+++ b/test/unit/model/DataBaseAccessTest.php
@@ -138,8 +138,9 @@ class DataBaseAccessTest extends TestCase
     public function testGetPermissions(array $userIds, array $resourceIds)
     {
         $query = sprintf(
-            'SELECT %s FROM %s WHERE resource_id IN (%s) AND user_id IN (%s)',
-            implode(', ', [DataBaseAccess::COLUMN_RESOURCE_ID, DataBaseAccess::COLUMN_PRIVILEGE]),
+            'SELECT %s, %s FROM %s WHERE resource_id IN (%s) AND user_id IN (%s)',
+            DataBaseAccess::COLUMN_RESOURCE_ID,
+            DataBaseAccess::COLUMN_PRIVILEGE,
             DataBaseAccess::TABLE_PRIVILEGES_NAME,
             implode(',', array_fill(0, count($resourceIds), '?')),
             implode(',', array_fill(0, count($userIds), '?'))

--- a/test/unit/model/DataBaseAccessTest.php
+++ b/test/unit/model/DataBaseAccessTest.php
@@ -74,11 +74,6 @@ class DataBaseAccessTest extends TestCase
         $reflector->setValue($this->sut, $this->persistenceMock);
     }
 
-    public function tearDown(): void
-    {
-        $this->sut = null;
-    }
-
     /**
      * @return array
      */

--- a/test/unit/model/DataBaseAccessTest.php
+++ b/test/unit/model/DataBaseAccessTest.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
@@ -17,23 +15,24 @@ declare(strict_types=1);
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  *
- * Copyright (c) 2014-2017 (original work) Open Assessment Technologies SA (under the project TAO-PRODUCT); *
- *
- *
+ * Copyright (c) 2014-2017 (original work) Open Assessment Technologies SA (under the project TAO-PRODUCT);
  */
+
+declare(strict_types=1);
 
 namespace oat\taoDacSimple\test\unit\model;
 
 use common_persistence_SqlPersistence;
+use common_persistence_Driver;
+use core_kernel_classes_Resource;
 use oat\generis\test\TestCase;
 use oat\oatbox\event\EventManager;
 use oat\taoDacSimple\model\DataBaseAccess;
 use oat\generis\test\MockObject;
 use oat\taoDacSimple\model\event\DacAddedEvent;
+use Generator;
 use PDO;
 use PDOStatement;
-use common_persistence_Driver;
-use core_kernel_classes_Resource;
 use Psr\Log\NullLogger;
 
 /**
@@ -50,24 +49,41 @@ class DataBaseAccessTest extends TestCase
     /**
      * @var DataBaseAccess
      */
-    protected $instance;
+    private $sut;
+
+    private $randomPermissionSets = [];
+
+    private static $knownPermissionTypes = ['GRANT', 'READ', 'WRITE'];
+
+    public static function setUpBeforeClass(): void
+    {
+        self::$knownPermissionTypes = array_flip(self::$knownPermissionTypes);
+    }
 
     public function setUp(): void
     {
-        $this->instance = new DataBaseAccess();
-        $this->instance->setLogger(new NullLogger());
+        $this->sut = new DataBaseAccess();
+        $this->sut->setLogger(new NullLogger());
+
+        $this->randomPermissionSets = [
+            [array_rand(self::$knownPermissionTypes, 1)],
+            array_rand(self::$knownPermissionTypes, 2),
+            array_rand(self::$knownPermissionTypes, 3)
+        ];
     }
 
     public function tearDown(): void
     {
-        $this->instance = null;
+        $this->sut = null;
+        $this->randomPermissionSets = [];
     }
 
     /**
      * Return a persistence Mock object supporting query()
      * @return MockObject
      */
-    public function getPersistenceMockForGetOps($queryParams, $queryFixture, $resultFixture) {
+    public function getPersistenceMockForGetOps($queryParams, $queryFixture, $resultFixture)
+    {
         $statementMock = $this->createMock(PDOStatement::class);
         $statementMock->expects($this->once())
             ->method('fetchAll')
@@ -104,7 +120,8 @@ class DataBaseAccessTest extends TestCase
      * Return a persistence Mock object supporting transactional() & insertMultiple()
      * @return MockObject
      */
-    public function getPersistenceMockForSetOps(int $numInsertMultipleCalls) {
+    public function getPersistenceMockForSetOps(int $numInsertMultipleCalls)
+    {
         $driverMock = $this->getMockForAbstractClass(
             common_persistence_Driver::class,
             [],
@@ -126,7 +143,7 @@ class DataBaseAccessTest extends TestCase
             ->expects($this->exactly($numInsertMultipleCalls))
             ->method('insertMultiple')
             ->with(DataBaseAccess::TABLE_PRIVILEGES_NAME, self::anything())
-            ->willReturnCallback(function($tableName, array $data, array $types = []) {
+            ->willReturnCallback(function ($tableName, array $data, array $types = []) {
                 return count($data);
             });
 
@@ -170,11 +187,10 @@ class DataBaseAccessTest extends TestCase
 
         $persistenceMock = $this->getPersistenceMockForGetOps($resourceIds, $queryFixture, $resultFixture);
 
-        $this->setPersistence($this->instance, $persistenceMock);
+        $this->setPersistence($this->sut, $persistenceMock);
 
-        $this->assertSame($resultFixture, $this->instance->getUsersWithPermissions($resourceIds));
+        $this->assertSame($resultFixture, $this->sut->getUsersWithPermissions($resourceIds));
     }
-
 
     /**
      * @return array
@@ -220,25 +236,27 @@ class DataBaseAccessTest extends TestCase
         ];
 
         $persistenceMock = $this->getPersistenceMockForGetOps($params, $query, $fetchResultFixture);
-        $this->setPersistence($this->instance, $persistenceMock);
+        $this->setPersistence($this->sut, $persistenceMock);
 
-        $this->assertEquals($resultFixture, $this->instance->getPermissions($userIds, $resourceIds));
-        $this->assertEquals([], $this->instance->getPermissions($userIds, []));
+        $this->assertEquals($resultFixture, $this->sut->getPermissions($userIds, $resourceIds));
+        $this->assertEquals([], $this->sut->getPermissions($userIds, []));
     }
 
     /**
      * @dataProvider addMultiplePermissionsEmptyScenariosDataProvider
      * @dataProvider addMultiplePermissionsBasicScenariosDataProvider
+     * @dataProvider addMultiplePermissionsBoundaryValues1
+     * @dataProvider addMultiplePermissionsBoundaryValues2
      */
-    public function testAddMultiplePermissions($numEvents, array $permissionData)
+    public function testAddMultiplePermissions($numEvents, $numInserts, array $permissionData)
     {
-        $numInserts = (int) ceil($numEvents / self::INSERT_CHUNK_SIZE);
+        echo "Expecting $numInserts inserts for $numEvents events\n";
 
         $persistenceMock = $this->getPersistenceMockForSetOps($numInserts);
-        $this->setPersistence($this->instance, $persistenceMock);
-        $this->setEventManager($this->instance, $numEvents);
+        $this->setPersistence($this->sut, $persistenceMock);
+        $this->setEventManager($this->sut, $numEvents);
 
-        $this->instance->addMultiplePermissions($permissionData);
+        $this->sut->addMultiplePermissions($permissionData);
     }
 
     public function addMultiplePermissionsEmptyScenariosDataProvider(): array
@@ -246,10 +264,12 @@ class DataBaseAccessTest extends TestCase
         return [
             'Empty arrays don\'t result in events nor queries' => [
                 'numEvents' => 0,
+                'numInserts' => 0,
                 'permissionData' => []
             ],
             'Empty permissions don\'t result in events nor queries' => [
                 'numEvents' => 0,
+                'numInserts' => 0,
                 'permissionData' => [
                     [
                         'resource' => $this->getResourceMock('123'),
@@ -265,6 +285,7 @@ class DataBaseAccessTest extends TestCase
         return [
             '3 permissions: One resource, single user' => [
                 'numEvents' => 3,
+                'numInserts' => 1,
                 'permissionData' => [
                     [
                         'resource' => $this->getResourceMock('123'),
@@ -276,6 +297,7 @@ class DataBaseAccessTest extends TestCase
             ],
             '6 permissions: One resource, two users' => [
                 'numEvents' => 6,
+                'numInserts' => 1,
                 'permissionData' => [
                     [
                         'resource' => $this->getResourceMock('123'),
@@ -289,10 +311,54 @@ class DataBaseAccessTest extends TestCase
         ];
     }
 
-    // @todo Tackle the "easy" (smaller) cases first
-    public function addMultiplePermissionsThousandsPermissionsDataProvider(): array
+    public function addMultiplePermissionsBoundaryValues1(): \Generator
     {
-        return [];
+        $sizes = range(self::INSERT_CHUNK_SIZE - 1, self::INSERT_CHUNK_SIZE + 1);
+
+        $resourceId = 100;
+        foreach ($sizes as $numPermissions) {
+            yield $this->getMultiplePermissionsScenario($resourceId, $numPermissions);
+            $resourceId++;
+        }
+    }
+
+    public function addMultiplePermissionsBoundaryValues2(): \Generator
+    {
+        $sizes = range((self::INSERT_CHUNK_SIZE * 2) - 1, (self::INSERT_CHUNK_SIZE * 2) + 1);
+
+        $resourceId = 200;
+        foreach ($sizes as $numPermissions) {
+            yield $this->getMultiplePermissionsScenario($resourceId, $numPermissions);
+            $resourceId++;
+        }
+    }
+
+    private function getMultiplePermissionsScenario(int $resourceId, int $numPermissions): array
+    {
+        // A single event and row is generated per user, resource and permission
+
+        return [
+            'numEvents' => $numPermissions,
+            'numInserts' => (int) ceil($numPermissions / self::INSERT_CHUNK_SIZE),
+            'permissionData' => [
+                [
+                    'resource' => $this->getResourceMock((string)($resourceId)),
+                    'permissions' => $this->getPermissionsArrayGenerator($numPermissions)
+                ]
+            ],
+        ];
+    }
+
+    private function getPermissionsArrayGenerator(int $numPermissions): Generator
+    {
+        $uid = 1;
+
+        for ($i = 0; $i < $numPermissions; $i++) {
+            // Using a reference to an existing array avoids the memory overhead for
+            // creating an array copy per permission (saves up to 30MB)
+            yield [$uid => &$this->randomPermissionSets[$i % 3]];
+            $uid++;
+        }
     }
 
     private function setPersistence(DataBaseAccess $instance, $persistenceMock)

--- a/test/unit/model/DataBaseAccessTest.php
+++ b/test/unit/model/DataBaseAccessTest.php
@@ -250,8 +250,6 @@ class DataBaseAccessTest extends TestCase
      */
     public function testAddMultiplePermissions($numEvents, $numInserts, array $permissionData)
     {
-        echo "Expecting $numInserts inserts for $numEvents events\n";
-
         $persistenceMock = $this->getPersistenceMockForSetOps($numInserts);
         $this->setPersistence($this->sut, $persistenceMock);
         $this->setEventManager($this->sut, $numEvents);

--- a/test/unit/model/eventHandler/ResourceUpdateHandlerTest.php
+++ b/test/unit/model/eventHandler/ResourceUpdateHandlerTest.php
@@ -118,10 +118,9 @@ class ResourceUpdateHandlerTest extends TestCase
 
         $this->permissionsServiceMock
             ->expects($this->once())
-            ->method('saveResourcePermissions')
+            ->method('saveResourcePermissionsRecursive')
             ->with(
-                true,
-                $this->resourceMock,
+                $this->eventMock->getMovedResource(),
                 [
                     'http://www.tao.lu/Ontologies/TAO.rdf#BackOfficeRole' => [
                         'GRANT',
@@ -132,6 +131,5 @@ class ResourceUpdateHandlerTest extends TestCase
             );
 
         $this->subject->catchResourceUpdated($this->eventMock);
-
     }
 }


### PR DESCRIPTION
Persist  new permissions using multiple `INSERT`s to prevent exceeding the maximum MySQL parameter count per query.

These changes use a batch size of **20K** permissions per `INSERT`. Given each permission stores values for 3 columns per row (i.e. per resource), we get `20K * 3 = 60K` parameters per query, which is less than the observed MySQL limit of **65K**. The "chunk size" is stored as a constant, but it probably can be moved to a config parameter if preferred.

Note the limit for MariaDB (used locally for development) seems higher than that (some sources cite ~1000 parameters, but I was able to go up to 250K parameters locally before giving up trying to reproduce the error). By the way, this change  makes TAO to issue various "smaller" queries (of 20K rows each) instead of a single, big one, which should be more resource friendly on the PHP side.

I'm also adding a couple of logger calls to improve observability, but that can be removed if you think that is not necessary.

**Associated Jira issue:** [ADF-654](https://oat-sa.atlassian.net/browse/ADF-654)

---
TODO
- [x] Review & fix things pointed out during code review
- [x] Check existing unit tests and adapt and/or add new ones
- [x] Wrap database operations in a DBAL transaction