### PR TITLE
feat: Hook DacSimplePermissionCopier into ClassCopier for assets if MediaManager is present

### DIFF
--- a/model/Copy/ServiceProvider/CopyServiceProvider.php
+++ b/model/Copy/ServiceProvider/CopyServiceProvider.php
@@ -66,9 +66,7 @@ class CopyServiceProvider implements ContainerServiceProviderInterface
                 ]
             );
 
-        // Is a recent version of MediaManager installed?
-        //
-        if (interface_exists(TaoMediaOntology::class)) {
+        if ($this->isMediaManagerInstalled()) {
             $services
                 ->get(ClassCopier::class . '::ASSETS')
                 ->call(
@@ -87,5 +85,10 @@ class CopyServiceProvider implements ContainerServiceProviderInterface
                     ]
                 );
         }
+    }
+
+    private function isMediaManagerInstalled(): bool
+    {
+        return interface_exists(TaoMediaOntology::class);
     }
 }

--- a/model/Copy/ServiceProvider/CopyServiceProvider.php
+++ b/model/Copy/ServiceProvider/CopyServiceProvider.php
@@ -29,6 +29,7 @@ use oat\tao\model\resources\Service\InstanceCopier;
 use oat\generis\model\DependencyInjection\ContainerServiceProviderInterface;
 use oat\taoDacSimple\model\Copy\Service\DacSimplePermissionCopier;
 use oat\taoDacSimple\model\DataBaseAccess;
+use oat\taoMediaManager\model\TaoMediaOntology;
 use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
 
 use function Symfony\Component\DependencyInjection\Loader\Configurator\service;
@@ -64,5 +65,27 @@ class CopyServiceProvider implements ContainerServiceProviderInterface
                     service(DacSimplePermissionCopier::class),
                 ]
             );
+
+        // Is a recent version of MediaManager installed?
+        //
+        if (interface_exists(TaoMediaOntology::class)) {
+            $services
+                ->get(ClassCopier::class . '::ASSETS')
+                ->call(
+                    'withPermissionCopier',
+                    [
+                        service(DacSimplePermissionCopier::class),
+                    ]
+                );
+
+            $services
+                ->get(InstanceCopier::class . '::ASSETS')
+                ->call(
+                    'withPermissionCopier',
+                    [
+                        service(DacSimplePermissionCopier::class),
+                    ]
+                );
+        }
     }
 }


### PR DESCRIPTION
**Associated Jira issue:** [ADF-1029](https://oat-sa.atlassian.net/browse/ADF-1029)

This PR adds a check inside `CopyServiceProvider` to check if a known interface introduced in the PR for handling ACLs in assets ([this one](https://github.com/oat-sa/extension-tao-mediamanager/pull/396/files)) is present and, if it is, registers `DacSimplePermissionCopier` as a permission copier inside the class copier for assets. This is done this way to avoid calling actual services (for example, extension manager) while compiling the container.

