### PR TITLE
fix: Preserve resource acl for moved resources

### DIFF
--- a/model/eventHandler/ResourceUpdateHandler.php
+++ b/model/eventHandler/ResourceUpdateHandler.php
@@ -60,7 +60,8 @@ class ResourceUpdateHandler extends ConfigurableService
             foreach ($itemPrivilegesMap as $uri => $itemPrivilege) {
                 $this->getPermissionService()
                     ->saveResourcePermissionsRecursive(
-                        $this->getResource($uri), $itemPrivilege
+                        $this->getResource($uri),
+                        $itemPrivilege
                     );
             }
         }

--- a/model/eventHandler/ResourceUpdateHandler.php
+++ b/model/eventHandler/ResourceUpdateHandler.php
@@ -37,9 +37,11 @@ class ResourceUpdateHandler extends ConfigurableService
 
     public function catchResourceUpdated(ResourceMovedEvent $event): void
     {
+        $permissionService = $this->getPermissionService();
+        $rolePrivilegeRetriever = $this->getRolePrivilegeRetriever();
         $movedResource = $event->getMovedResource();
 
-        $rolePrivilegeList = $this->getRolePrivilegeRetriever()->retrieveByResourceIds([
+        $rolePrivilegeList = $rolePrivilegeRetriever->retrieveByResourceIds([
             $event->getDestinationClass()->getUri(),
             $movedResource->getUri()
         ]);
@@ -47,18 +49,18 @@ class ResourceUpdateHandler extends ConfigurableService
         if ($movedResource->isClass()) {
             foreach ($movedResource->getInstances(true) as $item) {
                 $itemUri = $item->getUri();
-                $itemPrivilegesMap[$itemUri] =  $this->getRolePrivilegeRetriever()->retrieveByResourceIds([$itemUri]);
+                $itemPrivilegesMap[$itemUri] =  $rolePrivilegeRetriever->retrieveByResourceIds([$itemUri]);
             }
         }
 
-        $this->getPermissionService()->saveResourcePermissionsRecursive(
+        $permissionService->saveResourcePermissionsRecursive(
             $movedResource,
             $rolePrivilegeList
         );
 
         if (isset($itemPrivilegesMap)) {
             foreach ($itemPrivilegesMap as $uri => $itemPrivilege) {
-                $this->getPermissionService()
+                $permissionService
                     ->saveResourcePermissionsRecursive(
                         $this->getResource($uri),
                         $itemPrivilege


### PR DESCRIPTION
Preserve resources ACL rules for those resources moved together with moved class

How to reproduce:
1. Create Class
2. Create resource in class
3. Add custom ACL rules for resource
4. Move created class that contains your resource with custom ACL
5. Ensure moved recourse preserved ACL
