### PR TITLE
feat: Split ACL updates in subtas

### DIFF
--- a/model/Command/ChangePermissionsCommand.php
+++ b/model/Command/ChangePermissionsCommand.php
@@ -27,8 +27,6 @@ use core_kernel_classes_Resource;
 /**
  * Value object holding data about permission changes to be
  * done in a resource or class.
- *
- * @todo Should be immutable, add setXXX methods that return a new instance instead
  */
 class ChangePermissionsCommand
 {
@@ -55,27 +53,6 @@ class ChangePermissionsCommand
         $this->privilegesPerUser = $privileges;
         $this->isRecursive = $isRecursive;
         $this->applyToNestedResources = $applyToNestedResources;
-    }
-
-    public function recursive(): self
-    {
-        $ret = clone $this;
-        $ret->isRecursive = true;
-
-        return $ret;
-    }
-
-    public function nonRecursive(): self
-    {
-        $ret = clone $this;
-        $ret->isRecursive = false;
-
-        return $ret;
-    }
-
-    public function rootIsAClass(): bool
-    {
-        return $this->root->isClass();
     }
 
     /**

--- a/model/Command/ChangePermissionsCommand.php
+++ b/model/Command/ChangePermissionsCommand.php
@@ -1,5 +1,23 @@
 <?php
 
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2023 (original work) Open Assessment Technologies SA.
+ */
+
 namespace oat\taoDacSimple\model\Command;
 
 use core_kernel_classes_Resource;
@@ -25,22 +43,16 @@ class ChangePermissionsCommand
 
     private bool $applyToNestedResources;
 
-    private bool $skipClasses;
-
     public function __construct(
         core_kernel_classes_Resource $root,
         array $privileges,
         bool $isRecursive,
-        bool $applyToNestedResources,
-        bool $skipClasses
+        bool $applyToNestedResources
     ) {
         $this->root = $root;
         $this->privilegesPerUser = $privileges;
         $this->isRecursive = $isRecursive;
         $this->applyToNestedResources = $applyToNestedResources;
-
-        // @todo SkipClasses is always false
-        $this->skipClasses = $skipClasses;
     }
 
     public function recursive(): self
@@ -62,11 +74,6 @@ class ChangePermissionsCommand
     public function rootIsAClass(): bool
     {
         return $this->root->isClass();
-    }
-
-    public function getSkipClasses(): bool
-    {
-        return $this->skipClasses;
     }
 
     /**
@@ -99,13 +106,5 @@ class ChangePermissionsCommand
     public function applyToNestedResources(): bool
     {
         return $this->applyToNestedResources;
-    }
-
-    /**
-     * @return bool
-     */
-    public function skipClasses(): bool
-    {
-        return $this->skipClasses;
     }
 }

--- a/model/Command/ChangePermissionsCommand.php
+++ b/model/Command/ChangePermissionsCommand.php
@@ -39,20 +39,32 @@ class ChangePermissionsCommand
      */
     private array $privilegesPerUser;
 
-    private bool $isRecursive;
+    private bool $isRecursive = false;
 
-    private bool $applyToNestedResources;
+    private bool $applyToNestedResources = false;
 
     public function __construct(
         core_kernel_classes_Resource $root,
-        array $privileges,
-        bool $isRecursive,
-        bool $applyToNestedResources
+        array $privileges
     ) {
         $this->root = $root;
         $this->privilegesPerUser = $privileges;
-        $this->isRecursive = $isRecursive;
-        $this->applyToNestedResources = $applyToNestedResources;
+    }
+
+    public function withRecursion(bool $isRecursive = true): self
+    {
+        $ret = clone $this;
+        $ret->isRecursive = $isRecursive;
+
+        return $ret;
+    }
+
+    public function withNestedResources(): self
+    {
+        $ret = clone $this;
+        $ret->applyToNestedResources = true;
+
+        return $ret;
     }
 
     /**

--- a/model/Command/ChangePermissionsCommand.php
+++ b/model/Command/ChangePermissionsCommand.php
@@ -18,6 +18,8 @@
  * Copyright (c) 2023 (original work) Open Assessment Technologies SA.
  */
 
+declare(strict_types=1);
+
 namespace oat\taoDacSimple\model\Command;
 
 use core_kernel_classes_Resource;

--- a/model/Command/ChangePermissionsCommand.php
+++ b/model/Command/ChangePermissionsCommand.php
@@ -1,0 +1,74 @@
+<?php
+
+namespace oat\taoDacSimple\model\Command;
+
+use core_kernel_classes_Resource;
+
+/**
+ * Value object holding data about permission changes to be
+ * done in a resource or class.
+ */
+class ChangePermissionsCommand
+{
+    private core_kernel_classes_Resource $root;
+
+    /**
+     * An array in the form ['userId' => ['READ', 'WRITE], ...]
+     *
+     * @var string[]
+     */
+    private array $privilegesPerUser;
+
+    private bool $isRecursive;
+
+    private bool $applyToNestedResources;
+
+    public function __construct(
+        core_kernel_classes_Resource $root,
+        array $privileges,
+        bool $isRecursive,
+        bool $applyToNestedResources
+    ) {
+        $this->root = $root;
+        $this->privilegesPerUser = $privileges;
+        $this->isRecursive = $isRecursive;
+        $this->applyToNestedResources = $applyToNestedResources;
+    }
+
+    public function rootIsAClass(): bool
+    {
+        return $this->root->isClass();
+    }
+
+    /**
+     * @return core_kernel_classes_Resource
+     */
+    public function getRoot(): core_kernel_classes_Resource
+    {
+        return $this->root;
+    }
+
+    /**
+     * @return array
+     */
+    public function getPrivilegesPerUser(): array
+    {
+        return $this->privilegesPerUser;
+    }
+
+    /**
+     * @return bool
+     */
+    public function isRecursive(): bool
+    {
+        return $this->isRecursive;
+    }
+
+    /**
+     * @return bool
+     */
+    public function applyToNestedResources(): bool
+    {
+        return $this->applyToNestedResources;
+    }
+}

--- a/model/Command/ChangePermissionsCommand.php
+++ b/model/Command/ChangePermissionsCommand.php
@@ -59,10 +59,10 @@ class ChangePermissionsCommand
         return $ret;
     }
 
-    public function withNestedResources(): self
+    public function withNestedResources(bool $applyToNestedResources = true): self
     {
         $ret = clone $this;
-        $ret->applyToNestedResources = true;
+        $ret->applyToNestedResources = $applyToNestedResources;
 
         return $ret;
     }

--- a/model/Command/ChangePermissionsCommand.php
+++ b/model/Command/ChangePermissionsCommand.php
@@ -7,6 +7,8 @@ use core_kernel_classes_Resource;
 /**
  * Value object holding data about permission changes to be
  * done in a resource or class.
+ *
+ * @todo Should be immutable, add setXXX methods that return a new instance instead
  */
 class ChangePermissionsCommand
 {
@@ -23,21 +25,48 @@ class ChangePermissionsCommand
 
     private bool $applyToNestedResources;
 
+    private bool $skipClasses;
+
     public function __construct(
         core_kernel_classes_Resource $root,
         array $privileges,
         bool $isRecursive,
-        bool $applyToNestedResources
+        bool $applyToNestedResources,
+        bool $skipClasses
     ) {
         $this->root = $root;
         $this->privilegesPerUser = $privileges;
         $this->isRecursive = $isRecursive;
         $this->applyToNestedResources = $applyToNestedResources;
+
+        // @todo SkipClasses is always false
+        $this->skipClasses = $skipClasses;
+    }
+
+    public function recursive(): self
+    {
+        $ret = clone $this;
+        $ret->isRecursive = true;
+
+        return $ret;
+    }
+
+    public function nonRecursive(): self
+    {
+        $ret = clone $this;
+        $ret->isRecursive = false;
+
+        return $ret;
     }
 
     public function rootIsAClass(): bool
     {
         return $this->root->isClass();
+    }
+
+    public function getSkipClasses(): bool
+    {
+        return $this->skipClasses;
     }
 
     /**
@@ -70,5 +99,13 @@ class ChangePermissionsCommand
     public function applyToNestedResources(): bool
     {
         return $this->applyToNestedResources;
+    }
+
+    /**
+     * @return bool
+     */
+    public function skipClasses(): bool
+    {
+        return $this->skipClasses;
     }
 }

--- a/model/PermissionsService.php
+++ b/model/PermissionsService.php
@@ -52,8 +52,6 @@ class PermissionsService
         $this->eventManager = $eventManager;
     }
 
-    // @todo Fix unit tests
-
     /**
      * Updates the permissions for a set of resources based on the ACLs, root
      * resource and recursion parameters contained in the provided command.

--- a/model/PermissionsService.php
+++ b/model/PermissionsService.php
@@ -71,9 +71,6 @@ class PermissionsService
      *
      * - Otherwise (i.e. non-class roots), it updates only the resource set as
      *   the root resource for the command.
-     *
-     * @param ChangePermissionsCommand $command
-     * @return void
      */
     public function applyPermissions(ChangePermissionsCommand $command): void
     {

--- a/model/PermissionsService.php
+++ b/model/PermissionsService.php
@@ -136,7 +136,7 @@ class PermissionsService
     ): array {
         $delta = [];
 
-        foreach($currentResourcePermissions as $resourceId => $permissions) {
+        foreach ($currentResourcePermissions as $resourceId => $permissions) {
             $permissionsDelta = $this->strategy->normalizeRequest(
                 $permissions,
                 $command->getPrivilegesPerUser()

--- a/model/PermissionsService.php
+++ b/model/PermissionsService.php
@@ -87,7 +87,7 @@ class PermissionsService
         $this->wetRun($actions);
 
         $this->triggerEvents(
-            $permissionsDelta,
+            $permissionsDelta[$command->getRoot()->getUri()],
             $command->getRoot()->getUri(),
             $command->applyToNestedResources()
         );

--- a/model/PermissionsService.php
+++ b/model/PermissionsService.php
@@ -120,7 +120,7 @@ class PermissionsService
         $this->applyPermissions(
             (new ChangePermissionsCommand($class, $privilegesToSet))
                 ->withRecursion($isRecursive)
-                ->withNestedResources()
+                ->withNestedResources($isRecursive)
         );
     }
 

--- a/model/PermissionsService.php
+++ b/model/PermissionsService.php
@@ -80,7 +80,7 @@ class PermissionsService
 
         $this->dryRun($actions, $permissionsList);
         $this->wetRun($actions);
-        $this->triggerEvents($addRemove, $resource->getUri());
+        $this->triggerEvents($addRemove, $resource->getUri(), $applyToNestedResources);
     }
 
     public function savePermissions(
@@ -237,7 +237,7 @@ class PermissionsService
      * @param bool $isRecursive
      */
 
-    private function triggerEvents(array $addRemove, string $resourceId): void
+    private function triggerEvents(array $addRemove, string $resourceId, bool $processNestedResources): void
     {
         if (!empty($addRemove['add'])) {
             foreach ($addRemove['add'] as $userId => $rights) {
@@ -260,7 +260,7 @@ class PermissionsService
             new DataAccessControlChangedEvent(
                 $resourceId,
                 $addRemove,
-                false
+                $processNestedResources
             )
         );
     }

--- a/model/PermissionsStrategyAbstract.php
+++ b/model/PermissionsStrategyAbstract.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
@@ -21,6 +19,8 @@ declare(strict_types=1);
  *
  */
 
+declare(strict_types=1);
+
 namespace oat\taoDacSimple\model;
 
 use RuntimeException;
@@ -31,7 +31,7 @@ abstract class PermissionsStrategyAbstract implements PermissionsStrategyInterfa
     {
         $outputDiff = [];
 
-        if (!($this->is_assoc($array1) || $this->is_assoc($array2))) {
+        if (!($this->isAssociative($array1) || $this->isAssociative($array2))) {
             return array_values(array_diff($array1, $array2));
         }
 
@@ -39,7 +39,7 @@ abstract class PermissionsStrategyAbstract implements PermissionsStrategyInterfa
             if (array_key_exists($array1key, $array2)) {
                 if (is_array($array1value) && is_array($array2[$array1key])) {
                     $outputDiff[$array1key] = $this->arrayDiffRecursive($array1value, $array2[$array1key]);
-                } else  {
+                } else {
                     throw new RuntimeException('Inconsistent data');
                 }
             } else {
@@ -62,7 +62,7 @@ abstract class PermissionsStrategyAbstract implements PermissionsStrategyInterfa
     {
         $return = [];
 
-        if (!($this->is_assoc($array1) || $this->is_assoc($array2))) {
+        if (!($this->isAssociative($array1) || $this->isAssociative($array2))) {
             return array_intersect($array1, $array2);
         }
 
@@ -75,7 +75,7 @@ abstract class PermissionsStrategyAbstract implements PermissionsStrategyInterfa
                 if ($intersection) {
                     $return[$key] = $intersection;
                 }
-            } else if ($array1[$key] === $array2[$key]) {
+            } elseif ($array1[$key] === $array2[$key]) {
                 $return[$key] = $array1[$key];
             }
         }
@@ -83,7 +83,7 @@ abstract class PermissionsStrategyAbstract implements PermissionsStrategyInterfa
         return $return;
     }
 
-    private function is_assoc(array $array): bool
+    private function isAssociative(array $array): bool
     {
         return count(array_filter(array_keys($array), 'is_string')) > 0;
     }
@@ -107,8 +107,7 @@ abstract class PermissionsStrategyAbstract implements PermissionsStrategyInterfa
                 if ($privilegeIds) {
                     $add[$userId] = $privilegeIds;
                 }
-            } // compare privileges in db and request
-            else {
+            } else { // compare privileges in db and request
                 $tmp = array_values(array_diff($privilegeIds, $currentPrivileges[$userId]));
                 if ($tmp) {
                     $add[$userId] = $tmp;

--- a/model/PermissionsStrategyAbstract.php
+++ b/model/PermissionsStrategyAbstract.php
@@ -15,8 +15,7 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  *
- * Copyright (c) 2020 (original work) Open Assessment Technologies SA;
- *
+ * Copyright (c) 2020-2023 (original work) Open Assessment Technologies SA;
  */
 
 declare(strict_types=1);

--- a/model/PermissionsStrategyAbstract.php
+++ b/model/PermissionsStrategyAbstract.php
@@ -98,6 +98,9 @@ abstract class PermissionsStrategyAbstract implements PermissionsStrategyInterfa
      */
     public function getDeltaPermissions(array $currentPrivileges, array $privilegesToSet): array
     {
+        $add = [];
+        $remove = [];
+
         foreach ($privilegesToSet as $userId => $privilegeIds) {
             //if privileges are in request but not in db we add then
             if (!isset($currentPrivileges[$userId])) {

--- a/model/tasks/ChangePermissionsTask.php
+++ b/model/tasks/ChangePermissionsTask.php
@@ -93,7 +93,7 @@ class ChangePermissionsTask extends AbstractAction implements TaskAwareInterface
                 (new ChangePermissionsCommand($root, $privileges))
                     ->withNestedResources()
             );
-        } else if ($isRecursive) {
+        } elseif ($isRecursive) {
             $message = 'Starting recursive permissions update';
 
             $this->createSubtasksForClasses(

--- a/model/tasks/ChangePermissionsTask.php
+++ b/model/tasks/ChangePermissionsTask.php
@@ -87,7 +87,8 @@ class ChangePermissionsTask extends AbstractAction implements TaskAwareInterface
                 $service->savePermissions(
                     false,
                     $this->getClass($params[self::PARAM_RESOURCE]),
-                    $params[self::PARAM_PRIVILEGES]
+                    $params[self::PARAM_PRIVILEGES],
+                    $params[self::PARAM_NESTED_RESOURCES]
                 );
             }
 

--- a/model/tasks/ChangePermissionsTask.php
+++ b/model/tasks/ChangePermissionsTask.php
@@ -88,7 +88,7 @@ class ChangePermissionsTask extends AbstractAction implements TaskAwareInterface
                     false,
                     $this->getClass($params[self::PARAM_RESOURCE]),
                     $params[self::PARAM_PRIVILEGES],
-                    $params[self::PARAM_NESTED_RESOURCES]
+                    $params[self::PARAM_NESTED_RESOURCES] ?? false
                 );
             }
 

--- a/model/tasks/ChangePermissionsTask.php
+++ b/model/tasks/ChangePermissionsTask.php
@@ -17,24 +17,30 @@ declare(strict_types=1);
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  *
- * Copyright (c) 2020 (original work) Open Assessment Technologies SA;
- *
+ * Copyright (c) 2020-2023 (original work) Open Assessment Technologies SA;
  */
 
 namespace oat\taoDacSimple\model\tasks;
 
 use common_exception_MissingParameter;
 use common_report_Report as Report;
-use Exception;
-use JsonSerializable;
+use core_kernel_classes_Class;
 use oat\generis\model\OntologyAwareTrait;
 use oat\oatbox\extension\AbstractAction;
 use oat\oatbox\service\ServiceManagerAwareTrait;
 use oat\tao\model\taskQueue\QueueDispatcher;
+use oat\tao\model\taskQueue\QueueDispatcherInterface;
+use oat\tao\model\taskQueue\Task\CallbackTask;
 use oat\tao\model\taskQueue\Task\TaskAwareInterface;
 use oat\tao\model\taskQueue\Task\TaskAwareTrait;
+use oat\tao\model\taskQueue\Task\TaskInterface;
+use oat\tao\model\taskQueue\TaskLog;
+use oat\tao\model\taskQueue\TaskLogInterface;
+use oat\taoDacSimple\model\Command\ChangePermissionsCommand;
 use oat\taoDacSimple\model\PermissionsService;
 use oat\taoDacSimple\model\PermissionsServiceFactory;
+use Exception;
+use JsonSerializable;
 
 /**
  * Class ChangePermissionsTask
@@ -43,63 +49,196 @@ use oat\taoDacSimple\model\PermissionsServiceFactory;
  */
 class ChangePermissionsTask extends AbstractAction implements TaskAwareInterface, JsonSerializable
 {
-    use ServiceManagerAwareTrait;
+    use ServiceManagerAwareTrait; // Already implemented by AbstractAction
     use TaskAwareTrait;
     use OntologyAwareTrait;
 
-    public const PARAM_RECURSIVE = 'recursive';
     public const PARAM_RESOURCE = 'resource';
+    public const PARAM_RECURSIVE = 'recursive';
     public const PARAM_PRIVILEGES = 'privileges';
-    public const PARAM_NESTED_RESOURCES = 'nested_resources'; //FIXME Find better name
+    public const PARAM_IS_SUBCLASS = 'is_subclass';
+    public const PARAM_IS_SENTINEL = 'sentinel';
+    public const PARAM_SUBTASK_IDS = 'subtask_ids';
+
+    private const MANDATORY_PARAMS = [
+        self::PARAM_RESOURCE,
+        self::PARAM_PRIVILEGES
+    ];
 
     public function __invoke($params = []): Report
     {
         $this->validateParams($params);
 
+        $isSentinel = (bool) ($params[self::PARAM_IS_SENTINEL] ?? false);
+        $isRecursive = (bool) ($params[self::PARAM_RECURSIVE] ?? false);
+        $privileges = (array) $params[self::PARAM_PRIVILEGES];
+
         try {
-            $isRecursive = (bool)$params[self::PARAM_RECURSIVE];
+            $rootClass = $this->getClass($params[self::PARAM_RESOURCE]);
+
+            if ($isSentinel) {
+                return $this->handleSentinelRequest(
+                    $rootClass,
+                    $privileges,
+                    $params[self::PARAM_SUBTASK_IDS]
+                );
+            }
 
             if ($isRecursive) {
-                $queueDispatcher = $this->getServiceManager()->get(QueueDispatcher::SERVICE_ID);
-
-                $class = $this->getClass($params[self::PARAM_RESOURCE]);
-                $subClasses = $class->getSubClasses(true);
-                $allSubclasses = array_merge([$class], $subClasses);
-
-                foreach ($allSubclasses as $subCLass) {
-                    $queueDispatcher->createTask(
-                        new self(),
-                        [
-                            self::PARAM_RESOURCE => $subCLass->getUri(),
-                            self::PARAM_PRIVILEGES => $params[self::PARAM_PRIVILEGES],
-                            self::PARAM_RECURSIVE => false,
-                            self::PARAM_NESTED_RESOURCES => true,
-                        ],
-                        sprintf(
-                            'Processing permissions for class %s [%s]',
-                            $subCLass->getLabel(),
-                            $subCLass->getUri()
-                        )
-                    );
-                }
+                $this->handleRecursiveRequest($rootClass, $privileges);
             } else {
-                $service = $this->getPermissionService();
-                $service->savePermissions(
-                    false,
-                    $this->getClass($params[self::PARAM_RESOURCE]),
-                    $params[self::PARAM_PRIVILEGES],
-                    $params[self::PARAM_NESTED_RESOURCES] ?? false
+                $this->getPermissionService()->applyPermissions(
+                    new ChangePermissionsCommand($rootClass, $privileges, false, false)
                 );
             }
 
             $result = Report::createSuccess('Permissions saved');
         } catch (Exception $exception) {
-            $errMessage = sprintf('Saving permissions failed: %s', $exception->getMessage());
+            $errMessage = sprintf(
+                'Saving permissions failed: %s',
+                $exception->getMessage()
+            );
+
             $this->getLogger()->error($errMessage);
             $result = Report::createFailure($errMessage);
         }
 
         return $result;
+    }
+
+    /**
+     * Checks if all subtasks have finished for a recursive request: If they
+     * did, updates permissions for the root class itself, otherwise it
+     * enqueues a new task to recheck it later.
+     */
+    private function handleSentinelRequest(
+        core_kernel_classes_Class $rootClass,
+        array $privileges,
+        array $subtaskIds
+    ): Report {
+        foreach ($subtaskIds as $subtaskId) {
+            if (!$this->subtaskHasFinished($subtaskId)) {
+                $this->spawnSentinelTask($rootClass, $privileges, $subtaskIds);
+
+                return Report::createSuccess('Change permissions subtasks in progress');
+            }
+        }
+
+        $this->getPermissionService()->applyPermissions(
+            new ChangePermissionsCommand($rootClass, $privileges, false, true)
+        );
+
+        return Report::createSuccess("Permissions saved for root {$rootClass->getUri()}");
+    }
+
+    private function handleRecursiveRequest(
+        core_kernel_classes_Class $class,
+        array $privileges
+    ): void {
+        $subClasses = $class->getSubClasses(true); // NOT including the root
+        $allSubclasses = array_merge($subClasses);
+
+        /** @var CallbackTask[] $taskIds */
+        $taskIds = [];
+
+        foreach ($allSubclasses as $subClass) {
+            $task = $this->getDispatcher()->createTask(
+                new self(),
+                [
+                    self::PARAM_RESOURCE => $subClass->getUri(),
+                    self::PARAM_PRIVILEGES => $privileges,
+                    self::PARAM_RECURSIVE => false,
+                    self::PARAM_IS_SUBCLASS => true,
+                ],
+                sprintf(
+                    'Processing permissions for class %s [%s]',
+                    $subClass->getLabel(),
+                    $subClass->getUri()
+                )
+            );
+
+            $taskIds[] = $task->getId();
+        }
+
+        $this->spawnSentinelTask($class, $privileges, $taskIds);
+    }
+
+    /**
+     * PermissionsService::saveResourcePermissions uses the root class to
+     * compute the ACL diff, so we cannot change its permissions before all
+     * child classes/resources are changed.
+     *
+     * Also, we cannot enqueue a task to change the root until we are sure
+     * children have been processed (because then child classes would stop
+     * applying the correct permissions).
+     *
+     * @param core_kernel_classes_Class $class Class to update on tasks completion.
+     * @param array $privileges New class privileges.
+     * @param string[] $taskIds IDs of tasks to finish execution for.
+     */
+    private function spawnSentinelTask(
+        core_kernel_classes_Class $class,
+        array $privileges,
+        array $taskIds
+    ): void {
+        $this->getDispatcher()->createTask(
+            new self(),
+            [
+                self::PARAM_RESOURCE => $class->getUri(),
+                self::PARAM_PRIVILEGES => $privileges,
+                self::PARAM_IS_SENTINEL => true,
+                self::PARAM_SUBTASK_IDS => $taskIds, // array_map(
+                    //function (CallbackTask $task) {
+
+                /*
+                 * Argument 1 passed to oat\taoDacSimple\model\tasks\ChangePermissionsTask::
+                 *  oat\taoDacSimple\model\tasks\{closure}() must implement interface
+                 *  oat\tao\model\taskQueue\Task\TaskInterface, string given
+                 */
+                    /*function (TaskInterface $task) {
+                        return $task->getId();
+                    },
+                    $taskIds
+                ),*/
+            ],
+            sprintf(
+                'Process permissions for root class %s [%s]',
+                $class->getLabel(),
+                $class->getUri()
+            )
+        );
+    }
+
+    private function subtaskHasFinished(string $subtaskId): bool
+    {
+        $this->logDebug(
+            sprintf(
+                "Subtask %s status: %s",
+                $subtaskId,
+                $this->getTaskLog()->getStatus($subtaskId)
+            )
+        );
+
+        return in_array(
+            $this->getTaskLog()->getStatus($subtaskId),
+            [
+                TaskLogInterface::STATUS_COMPLETED,
+                TaskLogInterface::STATUS_CANCELLED,
+                TaskLogInterface::STATUS_ARCHIVED,
+                TaskLogInterface::STATUS_FAILED,
+                TaskLogInterface::STATUS_CHILD_RUNNING
+            ]
+        );
+    }
+
+    private function getTaskLog(): TaskLog
+    {
+        return $this->serviceLocator->get(TaskLog::SERVICE_ID);
+    }
+
+    private function getDispatcher(): QueueDispatcher
+    {
+        return $this->serviceLocator->get(QueueDispatcherInterface::SERVICE_ID);
     }
 
     private function getPermissionService(): PermissionsService
@@ -109,8 +248,7 @@ class ChangePermissionsTask extends AbstractAction implements TaskAwareInterface
 
     private function validateParams(array $params): void
     {
-        $knownParams = [self::PARAM_RECURSIVE, self::PARAM_PRIVILEGES, self::PARAM_RESOURCE];
-        foreach ($knownParams as $param) {
+        foreach (self::MANDATORY_PARAMS as $param) {
             if (!isset($params[$param])) {
                 throw new common_exception_MissingParameter(sprintf(
                     'Missing parameter `%s` in %s',

--- a/model/tasks/ChangePermissionsTask.php
+++ b/model/tasks/ChangePermissionsTask.php
@@ -108,7 +108,7 @@ class ChangePermissionsTask extends AbstractAction implements TaskAwareInterface
                         $privileges,
                         false, // isRecursive
                         true, // applyToNestedResources
-                        false // skipClasses
+                        //false // skipClasses
                     )
                 );
 
@@ -131,7 +131,7 @@ class ChangePermissionsTask extends AbstractAction implements TaskAwareInterface
                         $privileges,
                         false, // isRecursive
                         false, // applyToNestedResources
-                        false // skipClasses
+                        //false // skipClasses
                     )
                 );
 

--- a/model/tasks/ChangePermissionsTask.php
+++ b/model/tasks/ChangePermissionsTask.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
@@ -20,6 +18,8 @@ declare(strict_types=1);
  * Copyright (c) 2020-2023 (original work) Open Assessment Technologies SA;
  */
 
+declare(strict_types=1);
+
 namespace oat\taoDacSimple\model\tasks;
 
 use common_exception_MissingParameter;
@@ -27,15 +27,10 @@ use common_report_Report as Report;
 use core_kernel_classes_Class;
 use oat\generis\model\OntologyAwareTrait;
 use oat\oatbox\extension\AbstractAction;
-use oat\oatbox\service\ServiceManagerAwareTrait;
 use oat\tao\model\taskQueue\QueueDispatcher;
 use oat\tao\model\taskQueue\QueueDispatcherInterface;
-use oat\tao\model\taskQueue\Task\CallbackTask;
 use oat\tao\model\taskQueue\Task\TaskAwareInterface;
 use oat\tao\model\taskQueue\Task\TaskAwareTrait;
-use oat\tao\model\taskQueue\Task\TaskInterface;
-use oat\tao\model\taskQueue\TaskLog;
-use oat\tao\model\taskQueue\TaskLogInterface;
 use oat\taoDacSimple\model\Command\ChangePermissionsCommand;
 use oat\taoDacSimple\model\PermissionsService;
 use oat\taoDacSimple\model\PermissionsServiceFactory;
@@ -49,16 +44,13 @@ use JsonSerializable;
  */
 class ChangePermissionsTask extends AbstractAction implements TaskAwareInterface, JsonSerializable
 {
-    use ServiceManagerAwareTrait; // Already implemented by AbstractAction
     use TaskAwareTrait;
     use OntologyAwareTrait;
 
     public const PARAM_RESOURCE = 'resource';
-    public const PARAM_RECURSIVE = 'recursive';
     public const PARAM_PRIVILEGES = 'privileges';
-    public const PARAM_IS_SUBCLASS = 'is_subclass';
-    public const PARAM_IS_SENTINEL = 'sentinel';
-    public const PARAM_SUBTASK_IDS = 'subtask_ids';
+    public const PARAM_RECURSIVE = 'recursive';
+    public const PARAM_RECURSIVE_CLASS = 'recursive_class';
 
     private const MANDATORY_PARAMS = [
         self::PARAM_RESOURCE,
@@ -69,109 +61,71 @@ class ChangePermissionsTask extends AbstractAction implements TaskAwareInterface
     {
         $this->validateParams($params);
 
-        $isSentinel = (bool) ($params[self::PARAM_IS_SENTINEL] ?? false);
-        $isRecursive = (bool) ($params[self::PARAM_RECURSIVE] ?? false);
-        $isSubclass = (bool) ($params[self::PARAM_IS_SUBCLASS] ?? false);
-        $privileges = (array) $params[self::PARAM_PRIVILEGES];
-
         try {
-            $rootClass = $this->getClass($params[self::PARAM_RESOURCE]);
-
-            if ($isSentinel) {
-                return $this->handleSentinelRequest(
-                    $rootClass,
-                    $privileges,
-                    $params[self::PARAM_SUBTASK_IDS]
-                );
-            }
-
-            if ($isSubclass) {
-                // isSubclass always comes from isRecursive requests (they are created
-                // inside handleRecursiveRequest()).
-                //
-                // At this point, classes had their ACLs changed but resources contained
-                // within them still have the old permissions.
-                //
-                // However, resources within classes are not updated, likely because the
-                // permission delta is computed based on the root classes, so once we try
-                // to update the resources, the delta is empty and the resources remain
-                // unchanged.
-
-                $this->getLogger()->info(
-                    sprintf("isSubclass: %s [%s]", $rootClass->getUri(), $rootClass->getLabel())
-                );
-
-                // Apply permission changes to resources within the class
-                $this->getPermissionService()->applyPermissions(
-                    new ChangePermissionsCommand(
-                        $rootClass,
-                        $privileges,
-                        false, // isRecursive
-                        true, // applyToNestedResources
-                        //false // skipClasses
-                    )
-                );
-
-                $result = Report::createSuccess(
-                    sprintf(
-                        "Permissions saved for subclass %s [%s]",
-                        $rootClass->getUri(),
-                        $rootClass->getLabel()
-                    )
-                );
-
-            } else if ($isRecursive) {
-                $this->handleRecursiveRequest($rootClass, $privileges);
-
-                $result = Report::createSuccess('Starting recursive permissions update');
-            } else {
-                $this->getPermissionService()->applyPermissions(
-                    new ChangePermissionsCommand(
-                        $rootClass,
-                        $privileges,
-                        false, // isRecursive
-                        false, // applyToNestedResources
-                        //false // skipClasses
-                    )
-                );
-
-                $result = Report::createSuccess('Permissions saved');
-            }
-        } catch (Exception $exception) {
-            $errMessage = sprintf(
-                'Saving permissions failed: %s',
-                $exception->getMessage()
+            return $this->doHandle(
+                $this->getClass($params[self::PARAM_RESOURCE]),
+                (array) $params[self::PARAM_PRIVILEGES],
+                (bool) ($params[self::PARAM_RECURSIVE] ?? false),
+                (bool) ($params[self::PARAM_RECURSIVE_CLASS] ?? false)
             );
+        } catch (Exception $e) {
+            $errMessage = sprintf('Saving permissions failed: %s', $e->getMessage());
 
             $this->getLogger()->error($errMessage);
-            $result = Report::createFailure($errMessage);
+            return Report::createFailure($errMessage);
         }
-
-        return $result;
     }
 
-    private function handleRecursiveRequest(
-        core_kernel_classes_Class $class,
+    private function doHandle(
+        core_kernel_classes_Class $root,
+        array $privileges,
+        bool $isRecursive,
+        bool $isRecursiveClass
+    ): Report {
+        if ($isRecursiveClass) {
+            $message = sprintf(
+                "Permissions saved for resources under subclass %s [%s]",
+                $root->getUri(),
+                $root->getLabel()
+            );
+
+            $this->getPermissionService()->applyPermissions(
+                (new ChangePermissionsCommand($root, $privileges))
+                    ->withNestedResources()
+            );
+        } else if ($isRecursive) {
+            $message = 'Starting recursive permissions update';
+
+            $this->createSubtasksForClasses(
+                array_merge(
+                    [$root],
+                    $root->getSubClasses(true) // recursive, NOT including the root
+                ),
+                $privileges
+            );
+        } else {
+            $message = 'Permissions saved';
+
+            $this->getPermissionService()->applyPermissions(
+                new ChangePermissionsCommand($root, $privileges)
+            );
+        }
+
+        return Report::createSuccess($message);
+    }
+
+    private function createSubtasksForClasses(
+        array $allClasses,
         array $privileges
     ): void {
-        $allClasses = array_merge(
-            [$class],
-            $class->getSubClasses(true) // recursive, NOT including the root
-        );
-
-        $taskIds = [];
-
         foreach ($allClasses as $oneClass) {
-            $task = $this->getDispatcher()->createTask(
+            $this->getDispatcher()->createTask(
                 new self(),
                 [
                     self::PARAM_RESOURCE => $oneClass->getUri(),
                     self::PARAM_PRIVILEGES => $privileges,
                     self::PARAM_RECURSIVE => false,
-
-                    // @todo "IS_SUBCLASS" is not true anymore, it can be
-                    //       the root class as well -- rename the param name
-                    self::PARAM_IS_SUBCLASS => true,
+                    self::PARAM_RECURSIVE_CLASS => true,
                 ],
                 sprintf(
                     'Processing permissions for class %s [%s]',
@@ -179,114 +133,7 @@ class ChangePermissionsTask extends AbstractAction implements TaskAwareInterface
                     $oneClass->getUri()
                 )
             );
-
-            $taskIds[] = $task->getId();
         }
-
-        $this->spawnSentinelTask($class, $privileges, $taskIds);
-    }
-
-    /**
-     * Checks if all subtasks have finished for a recursive request: If they
-     * did, updates permissions for the root class itself, otherwise it
-     * enqueues a new task to recheck it later.
-     *
-     * @fixme Maybe not needed anymore
-     */
-    private function handleSentinelRequest(
-        core_kernel_classes_Class $rootClass,
-        array $privileges,
-        array $subtaskIds
-    ): Report {
-        foreach ($subtaskIds as $subtaskId) {
-            if (!$this->subtaskHasFinished($subtaskId)) {
-                $this->getLogger()->info("There are pending subtasks");
-                $this->spawnSentinelTask($rootClass, $privileges, $subtaskIds);
-
-                return Report::createSuccess('Change permissions subtasks in progress');
-            }
-        }
-
-        // @fixme WE NOW NEED TO APPLY THE CHANGES TO ITEMS IN EACH CLASS
-        //        INSTEAD BUT WE CANNOT COMPUTE THE DIFF BASED ON THE CLASSES
-        //        ANYMORE BECAUSE WE'VE ALREADY UPDATED CLASS PERMISSIONS
-        /*$this->getLogger()->info("Now applying permissions for classes");
-        $this->getPermissionService()->applyPermissions(
-            new ChangePermissionsCommand(
-                $rootClass,
-                $privileges,
-                false, // isRecursive
-                true, // applyToNestedResources
-                false // skipClasses
-            )
-        );*/
-
-        return Report::createSuccess(
-            "Permissions saved for root {$rootClass->getUri()}"
-        );
-    }
-
-    /**
-     * @todo Update/fix this docblock
-     *
-     * PermissionsService::saveResourcePermissions uses the root class to
-     * compute the ACL diff, so we cannot change its permissions before all
-     * child classes/resources are changed.
-     *
-     * Also, we cannot enqueue a task to change the root until we are sure
-     * children have been processed (because then child classes would stop
-     * applying the correct permissions).
-     *
-     * @param core_kernel_classes_Class $class Class to update on tasks completion.
-     * @param array $privileges New class privileges.
-     * @param string[] $taskIds IDs of tasks to finish execution for.
-     */
-    private function spawnSentinelTask(
-        core_kernel_classes_Class $class,
-        array $privileges,
-        array $taskIds
-    ): void {
-        $this->getDispatcher()->createTask(
-            new self(),
-            [
-                self::PARAM_RESOURCE => $class->getUri(),
-                self::PARAM_PRIVILEGES => $privileges,
-                self::PARAM_IS_SENTINEL => true,
-                self::PARAM_SUBTASK_IDS => $taskIds,
-            ],
-            sprintf(
-                'Process permissions for root class %s [%s]',
-                $class->getLabel(),
-                $class->getUri()
-            )
-        );
-    }
-
-    private function subtaskHasFinished(string $subtaskId): bool
-    {
-        $this->logDebug(
-            sprintf(
-                "Subtask %s status: %s",
-                $subtaskId,
-                $this->getTaskLog()->getStatus($subtaskId)
-            )
-        );
-
-        return in_array(
-            $this->getTaskLog()->getStatus($subtaskId),
-            [
-                TaskLogInterface::STATUS_COMPLETED,
-                TaskLogInterface::STATUS_CANCELLED,
-                TaskLogInterface::STATUS_ARCHIVED,
-                TaskLogInterface::STATUS_FAILED,
-                TaskLogInterface::STATUS_CHILD_RUNNING
-            ]
-        );
-    }
-
-    private function getTaskLog(): TaskLog
-    {
-        return $this->serviceLocator->get(TaskLog::SERVICE_ID);
     }
 
     private function getDispatcher(): QueueDispatcher
@@ -303,11 +150,13 @@ class ChangePermissionsTask extends AbstractAction implements TaskAwareInterface
     {
         foreach (self::MANDATORY_PARAMS as $param) {
             if (!isset($params[$param])) {
-                throw new common_exception_MissingParameter(sprintf(
-                    'Missing parameter `%s` in %s',
-                    $param,
-                    self::class
-                ));
+                throw new common_exception_MissingParameter(
+                    sprintf(
+                        'Missing parameter `%s` in %s',
+                        $param,
+                        self::class
+                    )
+                );
             }
         }
     }

--- a/test/unit/model/Command/ChangePermissionsCommandTest.php
+++ b/test/unit/model/Command/ChangePermissionsCommandTest.php
@@ -81,6 +81,7 @@ class ChangePermissionsCommandTest extends TestCase
         $sut = $source->withRecursion($isRecursive);
 
         $this->assertNotSame($source, $sut);
+        $this->assertFalse($sut->applyToNestedResources());
         $this->assertEquals($isRecursive, $sut->isRecursive());
     }
 
@@ -92,6 +93,32 @@ class ChangePermissionsCommandTest extends TestCase
             ],
             'isRecursive=false' => [
                 'isRecursive' => false,
+            ],
+        ];
+    }
+
+    /**
+     * @dataProvider withNestedResourcesGeneratesNewInstanceDataProvider
+     */
+    public function testWithNestedResourcesGeneratesNewInstance(
+        bool $applyToNestedResources
+    ): void {
+        $source = new ChangePermissionsCommand($this->root, []);
+        $sut = $source->withNestedResources($applyToNestedResources);
+
+        $this->assertNotSame($source, $sut);
+        $this->assertFalse($source->applyToNestedResources());
+        $this->assertEquals($applyToNestedResources, $sut->applyToNestedResources());
+    }
+
+    public function withNestedResourcesGeneratesNewInstanceDataProvider(): array
+    {
+        return [
+            'applyToNestedResources=true' => [
+                'applyToNestedResources' => true,
+            ],
+            'applyToNestedResources=false' => [
+                'applyToNestedResources' => false,
             ],
         ];
     }

--- a/test/unit/model/Command/ChangePermissionsCommandTest.php
+++ b/test/unit/model/Command/ChangePermissionsCommandTest.php
@@ -1,0 +1,98 @@
+<?php
+
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2023 (original work) Open Assessment Technologies SA;
+ */
+
+declare(strict_types=1);
+
+namespace oat\taoDacSimple\test\unit\model\Copy\Service;
+
+use core_kernel_classes_Resource;
+use oat\taoDacSimple\model\Command\ChangePermissionsCommand;
+use oat\taoDacSimple\model\Copy\Service\DacSimplePermissionCopier;
+use oat\taoDacSimple\model\DataBaseAccess;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+
+class ChangePermissionsCommandTest extends TestCase
+{
+    /**
+     * @var core_kernel_classes_Resource|MockObject
+     */
+    private core_kernel_classes_Resource $root;
+
+    public function setUp(): void
+    {
+        $this->root = $this->createMock(core_kernel_classes_Resource::class);
+    }
+
+    /**
+     * @dataProvider constructorDataProvider
+     */
+    public function testConstructor(array $privileges): void
+    {
+        $sut = new ChangePermissionsCommand($this->root, $privileges);
+
+        $this->assertSame($this->root, $sut->getRoot());
+        $this->assertSame($privileges, $sut->getPrivilegesPerUser());
+        $this->assertFalse($sut->isRecursive());
+        $this->assertFalse($sut->applyToNestedResources());
+    }
+
+    public function constructorDataProvider(): array
+    {
+        return [
+            'no permissions' => [
+                'privileges' => [],
+            ],
+            'READ' => [
+                'privileges' => ['READ'],
+            ],
+            'READ+WRITE' => [
+                'privileges' => ['READ', 'WRITE'],
+            ],
+            'READ+WRITE+GRANT' => [
+                'privileges' => ['READ', 'WRITE', 'GRANT'],
+            ],
+        ];
+    }
+
+    /**
+     * @dataProvider withRecursionGeneratesNewInstanceDataProvider
+     */
+    public function testWithRecursionGeneratesNewInstance(bool $isRecursive): void
+    {
+        $source = new ChangePermissionsCommand($this->root, []);
+        $sut = $source->withRecursion($isRecursive);
+
+        $this->assertNotSame($source, $sut);
+        $this->assertEquals($isRecursive, $sut->isRecursive());
+    }
+
+    public function withRecursionGeneratesNewInstanceDataProvider(): array
+    {
+        return [
+            'isRecursive=true' => [
+                'isRecursive' => true,
+            ],
+            'isRecursive=false' => [
+                'isRecursive' => false,
+            ],
+        ];
+    }
+}

--- a/test/unit/model/PermissionsServiceTest.php
+++ b/test/unit/model/PermissionsServiceTest.php
@@ -245,7 +245,7 @@ class PermissionsServiceTest extends TestCase
         $this->databaseAccess->expects($this->never())->method('addPermissions');
         $this->databaseAccess->expects($this->never())->method('removePermissions');
 
-        $this->databaseAccess->method('getResourcePermissions')->willReturn([]);
+        $this->databaseAccess->method('getResourcesPermissions')->willReturn([]);
 
         $this->strategy->method('normalizeRequest')->willReturn([]);
 
@@ -304,7 +304,13 @@ class PermissionsServiceTest extends TestCase
     {
         $this->eventManager->expects($this->at(0))
             ->method('trigger')
-            ->with(new DacRootAddedEvent($userId, $resourceId, ['GRANT', 'READ', 'WRITE']));
+            ->with(
+                new DacRootAddedEvent(
+                    $userId,
+                    $resourceId,
+                    ['GRANT', 'READ', 'WRITE']
+                )
+            );
 
         $this->eventManager->expects($this->at(1))
             ->method('trigger')

--- a/test/unit/model/PermissionsServiceTest.php
+++ b/test/unit/model/PermissionsServiceTest.php
@@ -15,8 +15,7 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  *
- * Copyright (c) 2020-2022 (original work) Open Assessment Technologies SA;
- *
+ * Copyright (c) 2020-2023 (original work) Open Assessment Technologies SA;
  */
 
 declare(strict_types=1);


### PR DESCRIPTION
**Associated Jira issue:** [ADF-1320](https://oat-sa.atlassian.net/browse/ADF-1320)

Changes in this PR make DAC Simple to create one individual task for each class to be updated in order to decrease the resource usage for individual tasks that were previously handling the whole process at once.

In order to do so, PermissionsService needs to be refactored to allow such partial updates, while also providing backwards compatibility for the old methods.

Related PR: to_be_filled