### PR TITLE
Solve compact() undefined variable issue 

### DIFF
--- a/model/PermissionsStrategyAbstract.php
+++ b/model/PermissionsStrategyAbstract.php
@@ -31,7 +31,7 @@ abstract class PermissionsStrategyAbstract implements PermissionsStrategyInterfa
     {
         $outputDiff = [];
 
-        if (!($this->is_assoc($array1) || $this->is_assoc($array2))) {
+        if (!($this->isAssoc($array1) || $this->isAssoc($array2))) {
             return array_values(array_diff($array1, $array2));
         }
 
@@ -39,7 +39,7 @@ abstract class PermissionsStrategyAbstract implements PermissionsStrategyInterfa
             if (array_key_exists($array1key, $array2)) {
                 if (is_array($array1value) && is_array($array2[$array1key])) {
                     $outputDiff[$array1key] = $this->arrayDiffRecursive($array1value, $array2[$array1key]);
-                } else  {
+                } else {
                     throw new RuntimeException('Inconsistent data');
                 }
             } else {
@@ -62,7 +62,7 @@ abstract class PermissionsStrategyAbstract implements PermissionsStrategyInterfa
     {
         $return = [];
 
-        if (!($this->is_assoc($array1) || $this->is_assoc($array2))) {
+        if (!($this->isAssoc($array1) || $this->isAssoc($array2))) {
             return array_intersect($array1, $array2);
         }
 
@@ -75,7 +75,7 @@ abstract class PermissionsStrategyAbstract implements PermissionsStrategyInterfa
                 if ($intersection) {
                     $return[$key] = $intersection;
                 }
-            } else if ($array1[$key] === $array2[$key]) {
+            } elseif ($array1[$key] === $array2[$key]) {
                 $return[$key] = $array1[$key];
             }
         }
@@ -83,7 +83,7 @@ abstract class PermissionsStrategyAbstract implements PermissionsStrategyInterfa
         return $return;
     }
 
-    private function is_assoc(array $array): bool
+    private function isAssoc(array $array): bool
     {
         return count(array_filter(array_keys($array), 'is_string')) > 0;
     }
@@ -107,8 +107,7 @@ abstract class PermissionsStrategyAbstract implements PermissionsStrategyInterfa
                 if ($privilegeIds) {
                     $add[$userId] = $privilegeIds;
                 }
-            } // compare privileges in db and request
-            else {
+            } else { // compare privileges in db and request
                 $tmp = array_values(array_diff($privilegeIds, $currentPrivileges[$userId]));
                 if ($tmp) {
                     $add[$userId] = $tmp;

--- a/model/PermissionsStrategyAbstract.php
+++ b/model/PermissionsStrategyAbstract.php
@@ -98,6 +98,9 @@ abstract class PermissionsStrategyAbstract implements PermissionsStrategyInterfa
      */
     public function getDeltaPermissions(array $currentPrivileges, array $privilegesToSet): array
     {
+        $add = [];
+        $remove = [];
+
         foreach ($privilegesToSet as $userId => $privilegeIds) {
             //if privileges are in request but not in db we add then
             if (!isset($currentPrivileges[$userId])) {

--- a/model/PermissionsStrategyAbstract.php
+++ b/model/PermissionsStrategyAbstract.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
@@ -20,6 +18,8 @@ declare(strict_types=1);
  * Copyright (c) 2020 (original work) Open Assessment Technologies SA;
  *
  */
+
+declare(strict_types=1);
 
 namespace oat\taoDacSimple\model;
 


### PR DESCRIPTION
# AUT-2884

## Description
For cases when `compact(): Undefined variable` generates 500 on the PHP level. Now it happens only if we have cases when `add` or `remove` variable is empty. The class will be moved if you will see 500, but ACL will be not applied.

Note:
https://www.php.net/manual/en/function.compact.php
Before PHP 7.3, any strings that are not set will silently be skipped.

## Changelog
- fix: Fix default values for $add and $remove variables

![image](https://user-images.githubusercontent.com/1053022/225276748-fac105a5-e305-4977-a71e-f1ebccfba118.png)


[AUT-2884]: https://oat-sa.atlassian.net/browse/AUT-2884?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ