### PR TITLE
feat: add link to tests permission provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,3 +112,9 @@ return new oat\taoDacSimple\model\PermissionsServiceFactory(
     ]
 );
 ```
+
+# Environment variables
+
+| Variable          | Description                      | Default value       | Values                                         |
+|-------------------|----------------------------------|---------------------|------------------------------------------------|
+| ACL_TRANSFER_MODE | Set the preferable transfer mode | `acl.keep.original` | `acl.keep.original`<br/> `acl.use.destination` |

--- a/composer.json
+++ b/composer.json
@@ -21,10 +21,10 @@
     "minimum-stability": "dev",
     "require": {
         "oat-sa/oatbox-extension-installer": "~1.1||dev-master",
-        "oat-sa/generis": ">=15.22",
-        "oat-sa/tao-core": "dev-feat/RFE-530/integration-branch as 52.0",
+        "oat-sa/generis": ">=15.24",
+        "oat-sa/tao-core": ">=52.1",
         "oat-sa/extension-tao-backoffice": ">=6.0.0",
-        "oat-sa/extension-tao-item": "dev-feat/RFE-530/integration-branch as 12.0"
+        "oat-sa/extension-tao-item": ">=11.3"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -22,9 +22,9 @@
     "require": {
         "oat-sa/oatbox-extension-installer": "~1.1||dev-master",
         "oat-sa/generis": ">=15.22",
-        "oat-sa/tao-core": ">=51.9.0",
+        "oat-sa/tao-core": "dev-feat/RFE-530/integration-branch as 52.0",
         "oat-sa/extension-tao-backoffice": ">=6.0.0",
-        "oat-sa/extension-tao-item": ">=11.29.0"
+        "oat-sa/extension-tao-item": "dev-feat/RFE-530/integration-branch as 12.0"
     },
     "autoload": {
         "psr-4": {

--- a/model/Copy/ServiceProvider/CopyServiceProvider.php
+++ b/model/Copy/ServiceProvider/CopyServiceProvider.php
@@ -15,7 +15,7 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  *
- * Copyright (c) 2022 (original work) Open Assessment Technologies SA;
+ * Copyright (c) 2022-2023 (original work) Open Assessment Technologies SA.
  *
  * @author Gabriel Felipe Soares <gabriel.felipe.soares@taotesting.com>
  */
@@ -24,9 +24,9 @@ declare(strict_types=1);
 
 namespace oat\taoDacSimple\model\Copy\ServiceProvider;
 
-use oat\generis\model\DependencyInjection\ContainerServiceProviderInterface;
-use oat\taoDacSimple\model\Copy\Service\DacSimplePermissionCopier;
 use oat\taoDacSimple\model\DataBaseAccess;
+use oat\taoDacSimple\model\Copy\Service\DacSimplePermissionCopier;
+use oat\generis\model\DependencyInjection\ContainerServiceProviderInterface;
 use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
 
 use function Symfony\Component\DependencyInjection\Loader\Configurator\service;
@@ -44,12 +44,6 @@ class CopyServiceProvider implements ContainerServiceProviderInterface
                     service(DataBaseAccess::SERVICE_ID),
                 ]
             )
-            ->tag('tao.copier.permissions')
-            ->tag('tao.copier.permissions.class.items')
-            ->tag('tao.copier.permissions.instance.items')
-            ->tag('tao.copier.permissions.class.tests')
-            ->tag('tao.copier.permissions.instance.tests')
-            ->tag('tao.copier.permissions.class.assets')
-            ->tag('tao.copier.permissions.instance.assets');
+            ->tag('tao.copier.permissions');
     }
 }

--- a/model/Copy/ServiceProvider/CopyServiceProvider.php
+++ b/model/Copy/ServiceProvider/CopyServiceProvider.php
@@ -25,10 +25,13 @@ declare(strict_types=1);
 namespace oat\taoDacSimple\model\Copy\ServiceProvider;
 
 use oat\taoDacSimple\model\DataBaseAccess;
+use oat\tao\model\clientConfig\ClientConfigStorage;
+use oat\tao\model\resources\Command\ResourceTransferCommand;
 use oat\taoDacSimple\model\Copy\Service\DacSimplePermissionCopier;
 use oat\generis\model\DependencyInjection\ContainerServiceProviderInterface;
 use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
 
+use function Symfony\Component\DependencyInjection\Loader\Configurator\env;
 use function Symfony\Component\DependencyInjection\Loader\Configurator\service;
 
 class CopyServiceProvider implements ContainerServiceProviderInterface
@@ -36,6 +39,7 @@ class CopyServiceProvider implements ContainerServiceProviderInterface
     public function __invoke(ContainerConfigurator $configurator): void
     {
         $services = $configurator->services();
+        $parameters = $configurator->parameters();
 
         $services
             ->set(DacSimplePermissionCopier::class, DacSimplePermissionCopier::class)
@@ -45,5 +49,24 @@ class CopyServiceProvider implements ContainerServiceProviderInterface
                 ]
             )
             ->tag('tao.copier.permissions');
+
+        $parameters->set('ACL_TRANSFER_MODE', ResourceTransferCommand::ACL_KEEP_ORIGINAL);
+
+        $services
+            ->get(ClientConfigStorage::class)
+            ->call(
+                'setConfigByPath',
+                [
+                    [
+                        'libConfigs' => [
+                            'layout/actions/common' => [
+                                'aclTransferMode' => env('ACL_TRANSFER_MODE')
+                                    ->default('ACL_TRANSFER_MODE')
+                                    ->string(),
+                            ],
+                        ],
+                    ],
+                ]
+            );
     }
 }

--- a/model/Copy/ServiceProvider/CopyServiceProvider.php
+++ b/model/Copy/ServiceProvider/CopyServiceProvider.php
@@ -44,6 +44,7 @@ class CopyServiceProvider implements ContainerServiceProviderInterface
                     service(DataBaseAccess::SERVICE_ID),
                 ]
             )
+            ->tag('tao.copier.permissions')
             ->tag('tao.copier.permissions.class.items')
             ->tag('tao.copier.permissions.instance.items')
             ->tag('tao.copier.permissions.class.tests')

--- a/model/Copy/ServiceProvider/CopyServiceProvider.php
+++ b/model/Copy/ServiceProvider/CopyServiceProvider.php
@@ -46,6 +46,8 @@ class CopyServiceProvider implements ContainerServiceProviderInterface
             )
             ->tag('tao.copier.permissions.class.items')
             ->tag('tao.copier.permissions.instance.items')
+            ->tag('tao.copier.permissions.class.tests')
+            ->tag('tao.copier.permissions.instance.tests')
             ->tag('tao.copier.permissions.class.assets')
             ->tag('tao.copier.permissions.instance.assets');
     }


### PR DESCRIPTION
https://oat-sa.atlassian.net/browse/RFE-530
https://oat-sa.atlassian.net/browse/ADF-1424
https://oat-sa.atlassian.net/browse/ADF-1425
https://oat-sa.atlassian.net/browse/ADF-1426
https://oat-sa.atlassian.net/browse/ADF-1427

# Goal

Add dynamic ACL strategy to `Move to` and `Copy to` features

# How to test

- Login to backoffice
- Play with the new ACL options for Items/Assets/Tests

# Related PRs

- https://github.com/oat-sa/extension-tao-item/pull/607
- https://github.com/oat-sa/extension-tao-mediamanager/pull/462
- https://github.com/oat-sa/extension-tao-test/pull/438
- https://github.com/oat-sa/tao-core/pull/3776
- https://github.com/oat-sa/generis/pull/1036