### PR TITLE
[Fix] Use delta of Root class permissions

### DIFF
--- a/model/Command/ChangePermissionsCommand.php
+++ b/model/Command/ChangePermissionsCommand.php
@@ -50,14 +50,18 @@ class ChangePermissionsCommand
 
     private bool $applyToNestedResources = false;
 
+    private array $permissionsDelta;
+
     public function __construct(
         core_kernel_classes_Resource $root,
         string $masterRequest,
-        array $privileges
+        array $privileges,
+        array $permissionsDelta
     ) {
         $this->root = $root;
         $this->masterRequest = $masterRequest;
         $this->privilegesPerUser = $privileges;
+        $this->permissionsDelta = $permissionsDelta;
     }
 
     /**
@@ -103,6 +107,11 @@ class ChangePermissionsCommand
     public function getPrivilegesPerUser(): array
     {
         return $this->privilegesPerUser;
+    }
+
+    public function getPermissionsDelta(): array
+    {
+        return $this->permissionsDelta;
     }
 
     public function isRecursive(): bool

--- a/test/unit/model/Command/ChangePermissionsCommandTest.php
+++ b/test/unit/model/Command/ChangePermissionsCommandTest.php
@@ -20,7 +20,7 @@
 
 declare(strict_types=1);
 
-namespace oat\taoDacSimple\test\unit\model\Copy\Service;
+namespace oat\taoDacSimple\test\unit\model\Command;
 
 use core_kernel_classes_Resource;
 use oat\taoDacSimple\model\Command\ChangePermissionsCommand;
@@ -44,14 +44,11 @@ class ChangePermissionsCommandTest extends TestCase
      */
     public function testConstructor(array $privileges): void
     {
-        $sut = new ChangePermissionsCommand(
-            $this->root,
-            $this->root->getUri(),
-            $privileges
-        );
+        $sut = new ChangePermissionsCommand($this->root, $this->root->getUri(), $privileges, []);
 
         $this->assertSame($this->root, $sut->getRoot());
         $this->assertSame($privileges, $sut->getPrivilegesPerUser());
+        $this->assertSame([], $sut->getPermissionsDelta());
         $this->assertFalse($sut->isRecursive());
         $this->assertFalse($sut->applyToNestedResources());
     }
@@ -76,11 +73,7 @@ class ChangePermissionsCommandTest extends TestCase
 
     public function testWithRecursion(): void
     {
-        $sut = new ChangePermissionsCommand(
-            $this->root,
-            $this->root->getUri(),
-            []
-        );
+        $sut = new ChangePermissionsCommand($this->root, $this->root->getUri(), [], []);
         $sut->withRecursion();
 
         $this->assertTrue($sut->isRecursive());
@@ -89,11 +82,7 @@ class ChangePermissionsCommandTest extends TestCase
 
     public function testWithNestedResources(): void
     {
-        $sut = new ChangePermissionsCommand(
-            $this->root,
-            $this->root->getUri(),
-            []
-        );
+        $sut = new ChangePermissionsCommand($this->root, $this->root->getUri(), [], []);
         $sut->withNestedResources();
 
         $this->assertFalse($sut->isRecursive());
@@ -102,11 +91,7 @@ class ChangePermissionsCommandTest extends TestCase
 
     public function testWithBoth(): void
     {
-        $sut = new ChangePermissionsCommand(
-            $this->root,
-            $this->root->getUri(),
-            []
-        );
+        $sut = new ChangePermissionsCommand($this->root, $this->root->getUri(), [], []);
         $sut->withRecursion();
         $sut->withNestedResources();
 


### PR DESCRIPTION
# [ADF-1541](https://oat-sa.atlassian.net/browse/ADF-1541)

## Changelog
* Instead of calculating permissions delta for every class, we will use permissions delta of the root class
* Added new task parameter to provide permissions delta
* Added new command parameter to provide permissions delta

[ADF-1541]: https://oat-sa.atlassian.net/browse/ADF-1541?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ