### PR TITLE
fix: fetch user in chunks to avoid DB query limits

### DIFF
--- a/model/DataBaseAccess.php
+++ b/model/DataBaseAccess.php
@@ -363,17 +363,18 @@ class DataBaseAccess extends ConfigurableService
      */
     public function checkPermissions($userIds)
     {
-        $chunks = array_chunk($userIds, $this->getOption(self::OPTION_FETCH_USER_PERMISSIONS_CHUNK_SIZE, 10));
+        $chunks = array_chunk($userIds, $this->getOption(self::OPTION_FETCH_USER_PERMISSIONS_CHUNK_SIZE, 20));
         $existingUsers = [];
 
         foreach ($chunks as $chunkUserIds) {
             $inQueryUser = implode(',', array_fill(0, count($chunkUserIds), ' ? '));
             $query = sprintf(
-                'SELECT %s FROM %s WHERE %s IN (%s)',
+                'SELECT %s FROM %s WHERE %s IN (%s) GROUP BY %s',
                 self::COLUMN_USER_ID,
                 self::TABLE_PRIVILEGES_NAME,
                 self::COLUMN_USER_ID,
-                $inQueryUser
+                $inQueryUser,
+                self::COLUMN_USER_ID
             );
             $results = $this->fetchQuery($query, array_values($chunkUserIds));
             foreach ($results as $result) {

--- a/model/DataBaseAccess.php
+++ b/model/DataBaseAccess.php
@@ -40,6 +40,7 @@ class DataBaseAccess extends ConfigurableService
     public const SERVICE_ID = 'taoDacSimple/DataBaseAccess';
 
     public const OPTION_PERSISTENCE = 'persistence';
+    public const OPTION_FETCH_USER_PERMISSIONS_CHUNK_SIZE = 'fetch_user_permissions_chunk_size';
 
     public const COLUMN_USER_ID = 'user_id';
     public const COLUMN_RESOURCE_ID = 'resource_id';
@@ -362,19 +363,25 @@ class DataBaseAccess extends ConfigurableService
      */
     public function checkPermissions($userIds)
     {
-        $inQueryUser = implode(',', array_fill(0, count($userIds), ' ? '));
-        $query = sprintf(
-            'SELECT %s FROM %s WHERE %s IN (%s)',
-            self::COLUMN_USER_ID,
-            self::TABLE_PRIVILEGES_NAME,
-            self::COLUMN_USER_ID,
-            $inQueryUser
-        );
-        $results = $this->fetchQuery($query, array_values($userIds));
-        foreach ($results as $result) {
-            $existsUsers[$result[self::COLUMN_USER_ID]] = $result[self::COLUMN_USER_ID];
+        $chunks = array_chunk($userIds, $this->getOption(self::OPTION_FETCH_USER_PERMISSIONS_CHUNK_SIZE, 10));
+        $existingUsers = [];
+
+        foreach ($chunks as $chunkUserIds) {
+            $inQueryUser = implode(',', array_fill(0, count($chunkUserIds), ' ? '));
+            $query = sprintf(
+                'SELECT %s FROM %s WHERE %s IN (%s)',
+                self::COLUMN_USER_ID,
+                self::TABLE_PRIVILEGES_NAME,
+                self::COLUMN_USER_ID,
+                $inQueryUser
+            );
+            $results = $this->fetchQuery($query, array_values($chunkUserIds));
+            foreach ($results as $result) {
+                $existingUsers[$result[self::COLUMN_USER_ID]] = $result[self::COLUMN_USER_ID];
+            }
         }
-        return $existsUsers ?? [];
+
+        return $existingUsers;
     }
 
     /**

--- a/test/unit/model/DataBaseAccessTest.php
+++ b/test/unit/model/DataBaseAccessTest.php
@@ -89,6 +89,41 @@ class DataBaseAccessTest extends TestCase
         ];
     }
 
+    public function testCheckPermissions(): void
+    {
+        $userIds = ['a', 'b', 'c'];
+
+        $statementMock = $this->getMockBuilder(PDOStatementForTest::class)
+            ->onlyMethods(['fetchAll'])
+            ->getMock();
+
+        $statementMock->expects($this->once())
+            ->method('fetchAll')
+            ->with(PDO::FETCH_ASSOC)
+            ->willReturn(
+                [
+                    [
+                        'user_id' => 'b',
+                    ]
+                ]
+            );
+
+        $this->persistenceMock
+            ->method('query')
+            ->with(
+                'SELECT user_id FROM data_privileges WHERE user_id IN ( ? , ? , ? ) GROUP BY user_id',
+                $userIds
+            )
+            ->willReturn($statementMock);
+
+        $this->assertSame(
+            [
+                'b' => 'b'
+            ],
+            $this->sut->checkPermissions($userIds)
+        );
+    }
+
     /**
      * @dataProvider resourceIdsProvider
      * @preserveGlobalState disable


### PR DESCRIPTION
https://oat-sa.atlassian.net/browse/OSD-4484
https://oat-sa.atlassian.net/browse/ADF-1542
https://oat-sa.atlassian.net/browse/OATSD-2578

# Goal 

Avoid breaking SQL response query size. This was breaking when we have big amount of users https://github.com/oat-sa/extension-tao-udir/blob/master/model/Acl/OnDacAffectedUsersHandler.php#L52

it seems here (https://github.com/oat-sa/extension-tao-dac-simple/blob/v7.10.4/model/DataBaseAccess.php#L366) we have queries that returned like a million rows, cause since there were not "group by" clause, we returned all the rows belonging to that users.

So, if one user had permissions set in "200k resources" (real case of the Customer) we would return "200k rows" just for this user. In the case, we were searching for 800 users with 200k resources = **160000000** rows.

# Solution

Why "Group by"? It was based on analysis and to keep the method backward compatible and reduce side effects and other changes. 

Benchmark: 

## Goupy by

```
        EXPLAIN ANALYZE SELECT user_id FROM data_privileges WHERE user_id IN ('https://qa-forfatter.eps.udir.no/#udir_1wd5XdAo0pGksTU=', 'https://qa-forfatter.eps.udir.no/#udir_1wh4VdEt05KmsjY=', 'https://qa-forfatter.eps.udir.no/#udir_1wh4XtAp0pGktDI=') GROUP BY user_id;

         HashAggregate  (cost=171240.53..171242.44 rows=191 width=55) (actual time=59.273..59.275 rows=3 loops=1)
   Group Key: user_id
   Batches: 1  Memory Usage: 40kB
   ->  Bitmap Heap Scan on data_privileges  (cost=9742.02..171090.86 rows=59866 width=55) (actual time=13.298..40.343 rows=90537 loops=1)
         Recheck Cond: ((user_id)::text = ANY ('{https://qa-forfatter.eps.udir.no/#udir_1wd5XdAo0pGksTU=,https://qa-forfatter.eps.udir.no/#udir_1wh4VdEt05KmsjY=,https://qa-forfatter.eps.udir.no/#udir_1wh4XtAp0pGktDI=}'::text[]))
         Heap Blocks: exact=9518
         ->  Bitmap Index Scan on data_privileges_pkey  (cost=0.00..9727.05 rows=59866 width=0) (actual time=11.544..11.544 rows=100840 loops=1)
               Index Cond: ((user_id)::text = ANY ('{https://qa-forfatter.eps.udir.no/#udir_1wd5XdAo0pGksTU=,https://qa-forfatter.eps.udir.no/#udir_1wh4VdEt05KmsjY=,https://qa-forfatter.eps.udir.no/#udir_1wh4XtAp0pGktDI=}'::text[]))
 Planning Time: 0.131 ms
 Execution Time: 59.451 ms
(10 rows)
```

### Distinct

```
        EXPLAIN ANALYZE SELECT DISTINCT user_id FROM data_privileges WHERE user_id IN ('https://qa-forfatter.eps.udir.no/#udir_1wd5XdAo0pGksTU=', 'https://qa-forfatter.eps.udir.no/#udir_1wh4VdEt05KmsjY=', 'https://qa-forfatter.eps.udir.no/#udir_1wh4XtAp0pGktDI=');

  HashAggregate  (cost=171240.53..171242.44 rows=191 width=55) (actual time=78.677..78.679 rows=3 loops=1)
   Group Key: user_id
   Batches: 1  Memory Usage: 40kB
   ->  Bitmap Heap Scan on data_privileges  (cost=9742.02..171090.86 rows=59866 width=55) (actual time=22.337..49.641 rows=90537 loops=1)
         Recheck Cond: ((user_id)::text = ANY ('{https://qa-forfatter.eps.udir.no/#udir_1wd5XdAo0pGksTU=,https://qa-forfatter.eps.udir.no/#udir_1wh4VdEt05KmsjY=,https://qa-forfatter.eps.udir.no/#udir_1wh4XtAp0pGktDI=}'::text[]))
         Heap Blocks: exact=9518
         ->  Bitmap Index Scan on data_privileges_pkey  (cost=0.00..9727.05 rows=59866 width=0) (actual time=20.607..20.607 rows=100840 loops=1)
               Index Cond: ((user_id)::text = ANY ('{https://qa-forfatter.eps.udir.no/#udir_1wd5XdAo0pGksTU=,https://qa-forfatter.eps.udir.no/#udir_1wh4VdEt05KmsjY=,https://qa-forfatter.eps.udir.no/#udir_1wh4XtAp0pGktDI=}'::text[]))
 Planning Time: 0.130 ms
 Execution Time: 78.909 ms
(10 rows)
```