### PR TITLE
feat: Create defaultRoleProvider Service

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
     "require": {
         "oat-sa/oatbox-extension-installer": "~1.1||dev-master",
         "oat-sa/generis": ">=16.0.0",
-        "oat-sa/tao-core": ">=54.29.1",
+        "oat-sa/tao-core": ">=54.43.0",
         "oat-sa/extension-tao-backoffice": ">=7.0.1",
         "oat-sa/extension-tao-item": ">=11.3"
     },

--- a/controller/AdminAccessController.php
+++ b/controller/AdminAccessController.php
@@ -29,6 +29,7 @@ use oat\oatbox\log\LoggerAwareTrait;
 use oat\oatbox\user\UserService;
 use oat\tao\model\taskQueue\QueueDispatcher;
 use oat\tao\model\taskQueue\TaskLogActionTrait;
+use oat\tao\model\accessControl\AclRoleProvider;
 use oat\taoDacSimple\model\AdminService;
 use oat\taoDacSimple\model\PermissionProvider;
 use oat\taoDacSimple\model\PermissionsServiceException;
@@ -91,6 +92,7 @@ class AdminAccessController extends tao_actions_CommonModule
         }
         $this->setData('users', $users);
         $this->setData('roles', $roles);
+        $this->setData('aclRolesSource', $this->getAclRoleProvider()->get());
         $this->setData('isClass', $resource->isClass());
 
         $permissionsServiceFactory = $this->getServiceLocator()->get(PermissionsServiceFactory::SERVICE_ID);
@@ -200,5 +202,10 @@ class AdminAccessController extends tao_actions_CommonModule
         }
 
         return $resourceId;
+    }
+
+    private function getAclRoleProvider(): AclRoleProvider
+    {
+        return $this->getPsrContainer()->get(AclRoleProvider::class);
     }
 }

--- a/manifest.php
+++ b/manifest.php
@@ -21,6 +21,7 @@
 use oat\taoDacSimple\model\Copy\ServiceProvider\CopyServiceProvider;
 use oat\taoDacSimple\model\ServiceProvider\PermissionsServiceProvider;
 use oat\taoDacSimple\scripts\install\AttachEventHandler;
+use oat\taoDacSimple\scripts\install\RegisterAclRoleProviderService;
 use oat\taoDacSimple\scripts\update\Updater;
 use oat\taoDacSimple\scripts\install\SetupDataAccess;
 use oat\taoDacSimple\scripts\install\RegisterAction;
@@ -43,7 +44,8 @@ return [
         'php' => [
             SetupDataAccess::class,
             RegisterAction::class,
-            AttachEventHandler::class
+            AttachEventHandler::class,
+            RegisterAclRoleProviderService::class
         ],
         'rdf' => [
             __DIR__ . '/model/ontology/dac.rdf',

--- a/migrations/Version202509091437153210_taoDacSimple.php
+++ b/migrations/Version202509091437153210_taoDacSimple.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace oat\taoDacSimple\migrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\Exception\IrreversibleMigration;
+use oat\tao\scripts\tools\migrations\AbstractMigration;
+use oat\taoDacSimple\scripts\install\RegisterAclRoleProviderService;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ *
+ * phpcs:disable Squiz.Classes.ValidClassName
+ */
+final class Version202509091437153210_taoDacSimple extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Registering DefaultAclRoleProvider as AclRoleProvider service';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->runAction(new RegisterAclRoleProviderService());
+    }
+
+    public function down(Schema $schema): void
+    {
+        throw new IrreversibleMigration('Cannot unregister the AclRoleProvider service automatically.');
+    }
+}

--- a/model/DefaultAclRoleProvider.php
+++ b/model/DefaultAclRoleProvider.php
@@ -26,7 +26,7 @@ use oat\generis\model\GenerisRdf;
 use oat\oatbox\service\ConfigurableService;
 use oat\tao\model\accessControl\AclRoleProvider;
 
-class DefaultAclRoleProvider extends ConfigurableService
+class DefaultAclRoleProvider extends ConfigurableService implements AclRoleProvider
 {
     public function get(): string
     {

--- a/model/DefaultAclRoleProvider.php
+++ b/model/DefaultAclRoleProvider.php
@@ -1,0 +1,35 @@
+<?php
+
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2025 (original work) Open Assessment Technologies SA;
+ */
+
+declare(strict_types=1);
+
+namespace oat\taoDacSimple\model;
+
+use oat\generis\model\GenerisRdf;
+use oat\oatbox\service\ConfigurableService;
+use oat\tao\model\accessControl\AclRoleProvider;
+
+class DefaultAclRoleProvider extends ConfigurableService
+{
+    public function get(): string
+    {
+        return GenerisRdf::CLASS_ROLE;
+    }
+}

--- a/scripts/install/RegisterAclRoleProviderService.php
+++ b/scripts/install/RegisterAclRoleProviderService.php
@@ -1,0 +1,37 @@
+<?php
+
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2025 (original work) Open Assessment Technologies SA;
+ */
+
+declare(strict_types=1);
+
+namespace oat\taoDacSimple\scripts\install;
+
+use oat\oatbox\extension\InstallAction;
+use oat\tao\model\accessControl\AclRoleProvider;
+use oat\taoDacSimple\model\DefaultAclRoleProvider;
+
+class RegisterAclRoleProviderService extends installAction
+{
+    public function __invoke($params)
+    {
+        if (!$this->getServiceManager()->has(AclRoleProvider::SERVICE_ID)) {
+            $this->getServiceManager()->register(AclRoleProvider::SERVICE_ID, new DefaultAclRoleProvider());
+        }
+    }
+}

--- a/views/templates/AdminAccessController/index.tpl
+++ b/views/templates/AdminAccessController/index.tpl
@@ -76,7 +76,7 @@
                             <div id="add-role-wrapper">
                                 <input type="text" id="add-role" style="width:100%" placeholder="<?= __('Add role(s)') ?>"
                                     data-url="<?= _url('search', 'Search', 'tao') ?>"
-                                    data-ontology="http://www.tao.lu/Ontologies/generis.rdf#ClassRole"
+                                    data-ontology=<?= $aclRolesSource ?>
                                     data-params-root="params" />
                             </div>
                         </div>


### PR DESCRIPTION
This Change will control ACL list that is used to search when assigning roles to resource. 

https://github.com/user-attachments/assets/f631044e-f43a-47e5-aa7a-b1521794beca

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Admin permissions page now uses a dynamic role source, improving role selection and autocomplete reliability.
  - Supports a configurable ACL role provider, enabling better alignment with custom role ontologies.

- Chores
  - Added installation and migration steps to automatically register a default ACL role provider during setup.
  - Ensures idempotent registration in fresh installs and upgrades.
  - No changes to public APIs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->